### PR TITLE
Creating tests

### DIFF
--- a/antd_service/src/routes/shared.rs
+++ b/antd_service/src/routes/shared.rs
@@ -94,4 +94,20 @@ mod tests {
         ));
         assert!(parse_payment_mode("bad").is_err());
     }
+
+    #[test]
+    fn decodes_base64_payloads_and_rejects_invalid_input() {
+        assert_eq!(decode_base64("YXV0dmlk").unwrap(), b"autvid");
+        assert!(decode_base64("%%%").is_err());
+    }
+
+    #[test]
+    fn parses_32_byte_hex_addresses_only() {
+        let address =
+            hex_to_address("abababababababababababababababababababababababababababababababab")
+                .unwrap();
+        assert_eq!(address, [0xab; 32]);
+        assert!(hex_to_address("ab").is_err());
+        assert!(hex_to_address("not-hex").is_err());
+    }
 }

--- a/react_frontend/src/App.test.jsx
+++ b/react_frontend/src/App.test.jsx
@@ -394,6 +394,85 @@ test("sends original-source and auto-publish options with an upload", async () =
   expect(uploadedForm.get("file")).toBe(file);
 });
 
+test("shows quote and upload errors without clearing the selected source", async () => {
+  vi.useFakeTimers();
+  window.localStorage.setItem(AUTH_STORAGE_KEY, "stored-token");
+  setupGetRoutes();
+
+  const realCreateElement = document.createElement.bind(document);
+  vi.spyOn(document, "createElement").mockImplementation((tagName, options) => {
+    const element = realCreateElement(tagName, options);
+    if (tagName === "video") {
+      Object.defineProperties(element, {
+        duration: { configurable: true, value: 20 },
+        videoHeight: { configurable: true, value: 720 },
+        videoWidth: { configurable: true, value: 1280 },
+        src: {
+          configurable: true,
+          get: () => "blob:video",
+          set: () => {
+            if (element.onloadedmetadata) element.onloadedmetadata();
+          },
+        },
+      });
+    }
+    return element;
+  });
+
+  let quoteAttempts = 0;
+  axios.post.mockImplementation((url, body, config) => {
+    if (url === "/api/videos/upload/quote") {
+      quoteAttempts += 1;
+      if (quoteAttempts === 1) {
+        return Promise.reject({ response: { data: { detail: "Quote service unavailable" } } });
+      }
+      return Promise.resolve({
+        data: {
+          estimated_bytes: 2048,
+          estimated_gas_cost_wei: "42",
+          payment_mode: "single",
+          sampled: false,
+          segment_count: 1,
+          storage_cost_atto: "1000000000000000000",
+        },
+      });
+    }
+    if (url === "/api/videos/upload") {
+      config.onUploadProgress({ loaded: 5, total: 10 });
+      return Promise.reject({ response: { data: { detail: "Upload disk full" } } });
+    }
+    return Promise.reject(new Error(`Unexpected POST ${url}`));
+  });
+
+  await renderApp();
+  await click(findButton("Upload"));
+
+  const fileInput = container.querySelector('input[type="file"]');
+  const file = new File(["source bytes"], "failure.mp4", { type: "video/mp4" });
+  await act(async () => {
+    Object.defineProperty(fileInput, "files", { configurable: true, value: [file] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+
+  await act(async () => {
+    vi.advanceTimersByTime(260);
+  });
+  await flushPromises();
+  expect(text()).toContain("Quote service unavailable");
+
+  await click(findButton("Current only"));
+  await act(async () => {
+    vi.advanceTimersByTime(260);
+  });
+  await flushPromises();
+  expect(text()).toContain("1 ANT");
+
+  await click(findButton("Upload source"));
+  await flushPromises();
+  expect(text()).toContain("Upload disk full");
+  expect(text()).toContain("failure.mp4");
+});
+
 test("approves an awaiting upload and deletes the video through admin controls", async () => {
   window.localStorage.setItem(AUTH_STORAGE_KEY, "stored-token");
   const adminVideo = {
@@ -472,6 +551,44 @@ test("approves an awaiting upload and deletes the video through admin controls",
     { headers: { Authorization: "Bearer stored-token" } },
   );
   expect(text()).not.toContain("Needs approval");
+});
+
+test("polls the admin library while videos are actively processing", async () => {
+  vi.useFakeTimers();
+  window.localStorage.setItem(AUTH_STORAGE_KEY, "stored-token");
+  let adminListCalls = 0;
+  axios.get.mockImplementation((url) => {
+    if (url === "/api/auth/me") {
+      return Promise.resolve({ data: { username: "admin" } });
+    }
+    if (url === "/api/videos") {
+      return Promise.resolve({ data: [] });
+    }
+    if (url === "/api/admin/videos") {
+      adminListCalls += 1;
+      return Promise.resolve({
+        data: [{
+          created_at: "2026-04-27T12:00:00Z",
+          id: "vid-processing",
+          status: "processing",
+          title: `Processing ${adminListCalls}`,
+        }],
+      });
+    }
+    return Promise.reject(new Error(`Unexpected GET ${url}`));
+  });
+
+  await renderApp();
+  await click(findButton("Manage"));
+  expect(text()).toContain("Processing 1");
+
+  await act(async () => {
+    vi.advanceTimersByTime(5000);
+  });
+  await flushPromises();
+
+  expect(adminListCalls).toBeGreaterThanOrEqual(2);
+  expect(text()).toContain("Processing 2");
 });
 
 test("keeps public catalog metadata redacted when filename and manifest are hidden", async () => {

--- a/rust_admin/src/antd_client.rs
+++ b/rust_admin/src/antd_client.rs
@@ -304,7 +304,47 @@ fn hex_lower(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::is_missing_file_upload_endpoint;
+    use std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
+
+    use axum::{
+        body::{to_bytes, Body},
+        extract::{Path, Query, State},
+        http::{HeaderMap, StatusCode},
+        response::IntoResponse,
+        routing::{get, post},
+        Json, Router,
+    };
+    use base64::Engine;
+    use tokio::fs as tokio_fs;
+    use tokio::sync::Mutex;
+    use uuid::Uuid;
+
+    use super::{
+        hex_lower, is_missing_file_upload_endpoint, AntdRestClient, Digest, Sha256, BASE64,
+    };
+    use crate::metrics::AdminMetrics;
+
+    #[derive(Clone, Default)]
+    struct MockAntdState {
+        cost_failures_remaining: Arc<AtomicUsize>,
+        cost_requests: Arc<AtomicUsize>,
+        last_file_upload: Arc<Mutex<Option<FileUploadObservation>>>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct FileUploadObservation {
+        body: Vec<u8>,
+        content_type: Option<String>,
+        payment_mode: Option<String>,
+        verify: Option<String>,
+        sha256: Option<String>,
+    }
 
     #[test]
     fn treats_stream_abort_on_file_upload_route_as_missing_endpoint() {
@@ -315,5 +355,242 @@ mod tests {
 
         let err = anyhow::anyhow!("error sending request for url (http://antd:8082/health)");
         assert!(!is_missing_file_upload_endpoint(&err));
+    }
+
+    #[tokio::test]
+    async fn mock_antd_client_exercises_json_wallet_data_and_file_routes() {
+        let mock_state = MockAntdState::default();
+        let base_url = spawn_mock_antd(mock_state.clone()).await;
+        let metrics = Arc::new(AdminMetrics::default());
+        let client = AntdRestClient::new(&base_url, 5.0, metrics.clone()).unwrap();
+
+        let health = client.health().await.unwrap();
+        assert_eq!(health.status, "ok");
+        assert_eq!(health.network.as_deref(), Some("mocknet"));
+
+        let wallet = client.wallet_address().await.unwrap();
+        assert_eq!(wallet.address, "0xabc123");
+        let balance = client.wallet_balance().await.unwrap();
+        assert_eq!(balance.balance, "1000");
+        assert_eq!(balance.gas_balance, "2000");
+        assert!(client.wallet_approve().await.unwrap().approved);
+
+        let cost = client.data_cost_for_size(1).await.unwrap();
+        assert_eq!(cost.cost.as_deref(), Some("321"));
+        assert_eq!(cost.chunk_count, Some(1));
+        assert_eq!(cost.estimated_gas_cost_wei.as_deref(), Some("654"));
+        assert_eq!(cost.payment_mode.as_deref(), Some("auto"));
+
+        let put = client.data_put_public(b"manifest", "merkle").await.unwrap();
+        assert_eq!(put.address, "data-address");
+        assert_eq!(put.cost.as_deref(), Some("111"));
+
+        let fetched = client.data_get_public("segment-address").await.unwrap();
+        assert_eq!(fetched, b"payload:segment-address");
+
+        let source_path =
+            std::env::temp_dir().join(format!("autvid_antd_client_file_{}.bin", Uuid::new_v4()));
+        tokio_fs::write(&source_path, b"file upload bytes")
+            .await
+            .unwrap();
+        let file = client
+            .file_put_public(&source_path, "auto", true)
+            .await
+            .unwrap();
+        let _ = tokio_fs::remove_file(&source_path).await;
+        assert_eq!(file.address, "file-address");
+        assert_eq!(file.byte_size, 17);
+        assert_eq!(file.storage_cost_atto, "222");
+        assert_eq!(file.payment_mode_used, "auto");
+
+        let upload = mock_state.last_file_upload.lock().await.clone().unwrap();
+        assert_eq!(upload.body, b"file upload bytes");
+        assert_eq!(
+            upload.content_type.as_deref(),
+            Some("application/octet-stream")
+        );
+        assert_eq!(upload.payment_mode.as_deref(), Some("auto"));
+        assert_eq!(upload.verify.as_deref(), Some("true"));
+        let mut hasher = Sha256::new();
+        hasher.update(b"file upload bytes");
+        let expected_sha = hex_lower(&hasher.finalize());
+        assert_eq!(upload.sha256.as_deref(), Some(expected_sha.as_str()));
+
+        let rendered = metrics.render_prometheus();
+        assert!(rendered.contains("autvid_admin_antd_requests_total{service=\"rust_admin\"} 8"));
+        assert!(
+            rendered.contains("autvid_admin_antd_request_errors_total{service=\"rust_admin\"} 0")
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_antd_cost_estimate_retries_transient_failures() {
+        let mock_state = MockAntdState::default();
+        mock_state
+            .cost_failures_remaining
+            .store(2, Ordering::Relaxed);
+        let base_url = spawn_mock_antd(mock_state.clone()).await;
+        let client =
+            AntdRestClient::new(&base_url, 5.0, Arc::new(AdminMetrics::default())).unwrap();
+
+        let cost = client.data_cost_for_size(3).await.unwrap();
+
+        assert_eq!(cost.cost.as_deref(), Some("321"));
+        assert_eq!(mock_state.cost_requests.load(Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn mock_antd_client_rejects_invalid_base64_downloads() {
+        let base_url = spawn_mock_antd(MockAntdState::default()).await;
+        let client =
+            AntdRestClient::new(&base_url, 5.0, Arc::new(AdminMetrics::default())).unwrap();
+
+        let err = client.data_get_public("bad-base64").await.unwrap_err();
+
+        assert!(err.to_string().contains("invalid base64 public data"));
+    }
+
+    async fn spawn_mock_antd(state: MockAntdState) -> String {
+        let app = Router::new()
+            .route("/health", get(mock_health))
+            .route("/v1/wallet/address", get(mock_wallet_address))
+            .route("/v1/wallet/balance", get(mock_wallet_balance))
+            .route("/v1/wallet/approve", post(mock_wallet_approve))
+            .route("/v1/data/cost", post(mock_data_cost))
+            .route("/v1/data/public", post(mock_data_put_public))
+            .route("/v1/data/public/:address", get(mock_data_get_public))
+            .route("/v1/file/public", post(mock_file_put_public))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    async fn mock_health() -> Json<serde_json::Value> {
+        Json(serde_json::json!({
+            "status": "ok",
+            "network": "mocknet",
+        }))
+    }
+
+    async fn mock_wallet_address() -> Json<serde_json::Value> {
+        Json(serde_json::json!({ "address": "0xabc123" }))
+    }
+
+    async fn mock_wallet_balance() -> Json<serde_json::Value> {
+        Json(serde_json::json!({
+            "balance": "1000",
+            "gas_balance": "2000",
+        }))
+    }
+
+    async fn mock_wallet_approve() -> Json<serde_json::Value> {
+        Json(serde_json::json!({ "approved": true }))
+    }
+
+    async fn mock_data_cost(
+        State(state): State<MockAntdState>,
+        Json(body): Json<serde_json::Value>,
+    ) -> axum::response::Response {
+        state.cost_requests.fetch_add(1, Ordering::Relaxed);
+        if state
+            .cost_failures_remaining
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
+        {
+            return (StatusCode::SERVICE_UNAVAILABLE, "cost unavailable").into_response();
+        }
+
+        let data = body
+            .get("data")
+            .and_then(serde_json::Value::as_str)
+            .unwrap();
+        assert!(BASE64.decode(data).unwrap().len() >= 3);
+        Json(serde_json::json!({
+            "cost": "321",
+            "chunk_count": 1,
+            "estimated_gas_cost_wei": "654",
+            "payment_mode": "auto",
+        }))
+        .into_response()
+    }
+
+    async fn mock_data_put_public(Json(body): Json<serde_json::Value>) -> Json<serde_json::Value> {
+        assert_eq!(
+            body.get("payment_mode").and_then(serde_json::Value::as_str),
+            Some("merkle")
+        );
+        assert_eq!(
+            BASE64
+                .decode(
+                    body.get("data")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap()
+                )
+                .unwrap(),
+            b"manifest"
+        );
+        Json(serde_json::json!({
+            "address": "data-address",
+            "cost": "111",
+        }))
+    }
+
+    async fn mock_data_get_public(Path(address): Path<String>) -> Json<serde_json::Value> {
+        if address == "bad-base64" {
+            return Json(serde_json::json!({ "data": "%%%" }));
+        }
+
+        Json(serde_json::json!({
+            "data": BASE64.encode(format!("payload:{address}")),
+        }))
+    }
+
+    async fn mock_file_put_public(
+        State(state): State<MockAntdState>,
+        Query(query): Query<HashMap<String, String>>,
+        headers: HeaderMap,
+        body: Body,
+    ) -> Json<serde_json::Value> {
+        let body = to_bytes(body, usize::MAX).await.unwrap().to_vec();
+        let mut hasher = Sha256::new();
+        hasher.update(&body);
+        let expected_sha = hex_lower(&hasher.finalize());
+        assert_eq!(
+            headers
+                .get("x-content-sha256")
+                .and_then(|value| value.to_str().ok()),
+            Some(expected_sha.as_str())
+        );
+        *state.last_file_upload.lock().await = Some(FileUploadObservation {
+            body: body.clone(),
+            content_type: headers
+                .get("content-type")
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string),
+            payment_mode: query.get("payment_mode").cloned(),
+            verify: query.get("verify").cloned(),
+            sha256: headers
+                .get("x-content-sha256")
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string),
+        });
+
+        Json(serde_json::json!({
+            "address": "file-address",
+            "byte_size": body.len(),
+            "chunks_stored": 2,
+            "total_chunks": 2,
+            "chunks_failed": 0,
+            "storage_cost_atto": "222",
+            "estimated_gas_cost_wei": "333",
+            "payment_mode_used": "auto",
+            "verified": true,
+        }))
     }
 }

--- a/rust_admin/src/catalog.rs
+++ b/rust_admin/src/catalog.rs
@@ -894,3 +894,235 @@ fn opt_string_field(value: &Value, key: &str) -> Option<String> {
 fn int_field(value: &Value, key: &str) -> i32 {
     value.get(key).and_then(Value::as_i64).unwrap_or_default() as i32
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        net::SocketAddr,
+        sync::{atomic::AtomicU64, Arc},
+    };
+
+    use axum::http::HeaderValue;
+    use sqlx::postgres::PgPoolOptions;
+    use tokio::sync::{Mutex, Semaphore};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{
+        antd_client::AntdRestClient,
+        metrics::AdminMetrics,
+        models::{PublicCatalogDocument, PublicCatalogVariant, PublicCatalogVideo},
+        state::AppState,
+    };
+
+    fn test_config(catalog_state_path: PathBuf) -> Config {
+        Config {
+            db_dsn: "postgresql://example".to_string(),
+            antd_url: "http://127.0.0.1:0".to_string(),
+            antd_payment_mode: "auto".to_string(),
+            antd_metadata_payment_mode: "merkle".to_string(),
+            admin_username: "admin".to_string(),
+            admin_password: "password".to_string(),
+            admin_auth_secret: "secret".to_string(),
+            admin_auth_ttl_hours: 12,
+            admin_auth_cookie_secure: false,
+            catalog_state_path,
+            catalog_bootstrap_address: None,
+            cors_allowed_origins: vec![HeaderValue::from_static("http://localhost")],
+            bind_addr: "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+            admin_request_timeout_seconds: 120.0,
+            admin_upload_request_timeout_seconds: 3600.0,
+            upload_temp_dir: std::env::temp_dir(),
+            upload_max_file_bytes: 20 * 1024 * 1024,
+            upload_min_free_bytes: 0,
+            upload_max_concurrent_saves: 1,
+            upload_ffprobe_timeout_seconds: 30.0,
+            hls_segment_duration: 1.0,
+            ffmpeg_threads: 1,
+            ffmpeg_filter_threads: 1,
+            ffmpeg_max_parallel_renditions: 1,
+            upload_max_duration_seconds: 3600.0,
+            upload_max_source_pixels: 1920 * 1080,
+            upload_max_source_long_edge: 1920,
+            upload_quote_transcoded_overhead: 1.08,
+            upload_quote_max_sample_bytes: 1024,
+            final_quote_approval_ttl_seconds: 3600,
+            approval_cleanup_interval_seconds: 300,
+            antd_upload_verify: false,
+            antd_upload_retries: 1,
+            antd_upload_timeout_seconds: 30.0,
+            antd_quote_concurrency: 1,
+            antd_upload_concurrency: 1,
+            antd_approve_on_startup: false,
+            antd_require_cost_ready: false,
+            antd_direct_upload_max_bytes: 1024,
+            admin_job_workers: 1,
+            admin_job_poll_interval_seconds: 1,
+            admin_job_lease_seconds: 60,
+            admin_job_max_attempts: 1,
+            catalog_publish_job_max_attempts: 1,
+        }
+    }
+
+    fn test_state(config: Config) -> AppState {
+        let metrics = Arc::new(AdminMetrics::default());
+        AppState {
+            config: Arc::new(config),
+            pool: PgPoolOptions::new()
+                .connect_lazy("postgresql://postgres:postgres@localhost/postgres")
+                .unwrap(),
+            antd: AntdRestClient::new("http://127.0.0.1:9", 1.0, metrics.clone()).unwrap(),
+            metrics,
+            catalog_lock: Arc::new(Mutex::new(())),
+            catalog_publish_lock: Arc::new(Mutex::new(())),
+            catalog_publish_epoch: Arc::new(AtomicU64::new(0)),
+            upload_save_semaphore: Arc::new(Semaphore::new(1)),
+        }
+    }
+
+    #[test]
+    fn invalid_catalog_state_is_quarantined_to_broken_file() {
+        let dir = std::env::temp_dir().join(format!("autvid_catalog_{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("catalog.json");
+        fs::write(&path, "not valid json").unwrap();
+        let config = test_config(path.clone());
+
+        assert!(read_catalog_state_value(&config).is_none());
+
+        assert!(!path.exists());
+        assert!(path.with_file_name("catalog.json.broken").exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn write_catalog_state_persists_snapshot_and_pending_flag() {
+        let dir = std::env::temp_dir().join(format!("autvid_catalog_{}", Uuid::new_v4()));
+        let path = dir.join("catalog.json");
+        let config = test_config(path.clone());
+        let catalog = PublicCatalogDocument {
+            schema_version: 1,
+            content_type: CATALOG_CONTENT_TYPE.to_string(),
+            updated_at: "2026-05-05T00:00:00Z".to_string(),
+            videos: vec![PublicCatalogVideo {
+                id: "video-1".to_string(),
+                title: "Example".to_string(),
+                original_filename: None,
+                description: None,
+                status: STATUS_READY.to_string(),
+                created_at: "2026-05-05T00:00:00Z".to_string(),
+                updated_at: "2026-05-05T00:00:01Z".to_string(),
+                manifest_address: "manifest-address".to_string(),
+                show_original_filename: false,
+                show_manifest_address: false,
+                variants: vec![PublicCatalogVariant {
+                    resolution: "720p".to_string(),
+                    width: 1280,
+                    height: 720,
+                    segment_count: 1,
+                    total_duration: Some(6.0),
+                }],
+            }],
+        };
+
+        write_catalog_state(&config, Some("catalog-address"), Some(&catalog), true).unwrap();
+
+        let payload: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(payload["catalog_address"], "catalog-address");
+        assert_eq!(payload["publish_pending"], true);
+        assert_eq!(payload["catalog"]["videos"][0]["id"], "video-1");
+        assert!(!path.with_extension("tmp").exists());
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn catalog_entry_to_video_out_applies_public_visibility() {
+        let entry = json!({
+            "id": "video-1",
+            "title": "Public Video",
+            "description": "Visible summary",
+            "status": STATUS_READY,
+            "created_at": "2026-05-05T00:00:00Z",
+            "manifest_address": "manifest-address",
+            "show_manifest_address": false,
+            "variants": [{
+                "resolution": "720p",
+                "width": 1280,
+                "height": 720,
+                "segment_count": 2,
+                "total_duration": 12.5
+            }]
+        });
+
+        let video = catalog_entry_to_video_out(&entry, Some("catalog-address"));
+
+        assert_eq!(video.id, "video-1");
+        assert_eq!(video.manifest_address, None);
+        assert_eq!(video.catalog_address.as_deref(), Some("catalog-address"));
+        assert!(video.is_public);
+        assert!(!video.show_original_filename);
+        assert_eq!(video.variants.len(), 1);
+        assert_eq!(video.variants[0].segment_count, Some(2));
+    }
+
+    #[tokio::test]
+    async fn manifest_to_video_out_hides_sensitive_fields_for_public_view() {
+        let dir = std::env::temp_dir().join(format!("autvid_catalog_{}", Uuid::new_v4()));
+        let mut config = test_config(dir.join("catalog.json"));
+        config.catalog_bootstrap_address = Some("catalog-bootstrap".to_string());
+        let state = test_state(config);
+        let manifest = json!({
+            "id": "video-1",
+            "title": "Demo",
+            "original_filename": "raw-source.mov",
+            "description": "Internal upload",
+            "status": STATUS_READY,
+            "created_at": "2026-05-05T00:00:00Z",
+            "show_original_filename": true,
+            "show_manifest_address": false,
+            "original_file": {
+                "autonomi_address": "original-address",
+                "byte_size": 12345
+            },
+            "variants": [{
+                "resolution": "720p",
+                "width": 1280,
+                "height": 720,
+                "segment_count": 1,
+                "total_duration": 6.0,
+                "segments": [{
+                    "segment_index": 0,
+                    "autonomi_address": "segment-address",
+                    "duration": 6.0
+                }]
+            }]
+        });
+
+        let admin_view = manifest_to_video_out(&state, &manifest, Some("manifest-address"), false);
+        assert_eq!(
+            admin_view.original_filename.as_deref(),
+            Some("raw-source.mov")
+        );
+        assert_eq!(
+            admin_view.manifest_address.as_deref(),
+            Some("manifest-address")
+        );
+        assert_eq!(
+            admin_view.catalog_address.as_deref(),
+            Some("catalog-bootstrap")
+        );
+        assert_eq!(
+            admin_view.original_file_address.as_deref(),
+            Some("original-address")
+        );
+        assert_eq!(admin_view.variants[0].segments.len(), 1);
+
+        let public_view = manifest_to_video_out(&state, &manifest, Some("manifest-address"), true);
+        assert_eq!(public_view.original_filename, None);
+        assert_eq!(public_view.manifest_address, None);
+        assert_eq!(public_view.catalog_address, None);
+        assert_eq!(public_view.original_file_address, None);
+        assert!(public_view.variants[0].segments.is_empty());
+    }
+}

--- a/rust_admin/src/jobs.rs
+++ b/rust_admin/src/jobs.rs
@@ -639,7 +639,12 @@ fn recover_source_path(job_dir: Option<&FsPath>, job_source_path: Option<&str>) 
 
 #[cfg(test)]
 mod tests {
-    use super::job_retry_delay_seconds;
+    use std::{fs, path::PathBuf};
+
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use super::{decode_requested_resolutions, job_retry_delay_seconds, recover_source_path};
 
     #[test]
     fn durable_job_retry_backoff_caps() {
@@ -647,5 +652,45 @@ mod tests {
         assert_eq!(job_retry_delay_seconds(2), 60);
         assert_eq!(job_retry_delay_seconds(6), 900);
         assert_eq!(job_retry_delay_seconds(20), 900);
+    }
+
+    #[test]
+    fn recovery_resolution_decode_accepts_arrays_and_legacy_strings() {
+        assert_eq!(
+            decode_requested_resolutions(Some(json!(["1080p", "720p", "bogus"]))),
+            vec!["1080p".to_string(), "720p".to_string()]
+        );
+        assert_eq!(
+            decode_requested_resolutions(Some(json!("480p,360p,unknown"))),
+            vec!["480p".to_string(), "360p".to_string()]
+        );
+        assert!(decode_requested_resolutions(Some(json!({ "bad": true }))).is_empty());
+    }
+
+    #[test]
+    fn recovery_source_path_prefers_existing_explicit_path_then_original_file() {
+        let dir = std::env::temp_dir().join(format!("autvid_job_recover_{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        let explicit = dir.join("custom-source.mp4");
+        let fallback = dir.join("original_upload.mp4");
+        fs::write(&explicit, b"explicit").unwrap();
+        fs::write(&fallback, b"fallback").unwrap();
+
+        assert_eq!(
+            recover_source_path(Some(&dir), Some(explicit.to_str().unwrap())),
+            Some(explicit.clone())
+        );
+
+        assert_eq!(
+            recover_source_path(Some(&dir), Some("/definitely/missing/source.mp4")),
+            Some(fallback.clone())
+        );
+
+        assert_eq!(
+            recover_source_path(Some(&PathBuf::from("/definitely/missing/job-dir")), None),
+            None
+        );
+
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/rust_admin/src/media.rs
+++ b/rust_admin/src/media.rs
@@ -702,7 +702,15 @@ pub(crate) fn enforce_upload_media_limits(
 
 #[cfg(test)]
 mod tests {
-    use super::{estimate_transcoded_bytes, target_dimensions_for_source};
+    use std::fs;
+
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use super::{
+        collect_segment_files, estimate_transcoded_bytes, parse_probe_duration,
+        stream_rotation_degrees, target_dimensions_for_source, target_video_bitrate_kbps,
+    };
 
     #[test]
     fn target_dimensions_follow_source_orientation() {
@@ -731,5 +739,61 @@ mod tests {
     #[test]
     fn estimate_transcoded_bytes_uses_bitrate_and_overhead() {
         assert_eq!(estimate_transcoded_bytes(1.0, 500, 96, 1.08), 80460);
+    }
+
+    #[test]
+    fn probe_duration_prefers_stream_then_format_positive_values() {
+        let stream = json!({ "duration": "6.25" });
+        let data = json!({ "format": { "duration": "9.5" } });
+        assert_eq!(parse_probe_duration(&data, &stream), Some(6.25));
+
+        let stream = json!({ "duration": "N/A" });
+        let data = json!({ "format": { "duration": 9.5 } });
+        assert_eq!(parse_probe_duration(&data, &stream), Some(9.5));
+
+        let stream = json!({ "duration": -1.0 });
+        let data = json!({ "format": { "duration": 0.0 } });
+        assert_eq!(parse_probe_duration(&data, &stream), None);
+    }
+
+    #[test]
+    fn stream_rotation_reads_tags_and_side_data() {
+        assert_eq!(
+            stream_rotation_degrees(&json!({ "tags": { "rotate": "-90" } })),
+            270
+        );
+        assert_eq!(
+            stream_rotation_degrees(&json!({
+                "side_data_list": [{ "rotation": 90.0 }]
+            })),
+            90
+        );
+        assert_eq!(stream_rotation_degrees(&json!({})), 0);
+    }
+
+    #[test]
+    fn target_video_bitrate_scales_by_rendered_pixels() {
+        assert_eq!(target_video_bitrate_kbps(5_000, 1920, 1080, 960, 540), 1250);
+        assert_eq!(target_video_bitrate_kbps(10, 1920, 1080, 256, 144), 64);
+    }
+
+    #[test]
+    fn collect_segment_files_orders_numbered_segments_only() {
+        let dir = std::env::temp_dir().join(format!("autvid_segments_{}", Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("seg_00010.ts"), b"10").unwrap();
+        fs::write(dir.join("seg_00002.ts"), b"2").unwrap();
+        fs::write(dir.join("not_a_segment.ts"), b"ignored").unwrap();
+        fs::write(dir.join("seg_bad.ts"), b"last").unwrap();
+        fs::write(dir.join("seg_00001.mp4"), b"ignored extension").unwrap();
+
+        let files = collect_segment_files(&dir).unwrap();
+        let names = files
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["seg_00002.ts", "seg_00010.ts", "seg_bad.ts"]);
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/rust_admin/src/upload.rs
+++ b/rust_admin/src/upload.rs
@@ -386,7 +386,9 @@ pub(crate) fn format_bytes(byte_count: u64) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_resolutions, sanitize_upload_filename};
+    use axum::http::{header, HeaderMap, HeaderValue};
+
+    use super::{content_length, parse_form_bool, parse_resolutions, sanitize_upload_filename};
 
     #[test]
     fn sanitizes_upload_filename_like_admin_service() {
@@ -403,5 +405,30 @@ mod tests {
             parse_resolutions("720p, nope,1440p,1080p,4k"),
             vec!["720p", "1440p", "1080p", "4k"]
         );
+    }
+
+    #[test]
+    fn parses_form_booleans_from_common_browser_values() {
+        for truthy in ["1", "true", "TRUE", "yes", "on", " On "] {
+            assert!(parse_form_bool(truthy), "{truthy} should be truthy");
+        }
+        for falsy in ["0", "false", "no", "off", "", "maybe"] {
+            assert!(!parse_form_bool(falsy), "{falsy} should be falsy");
+        }
+    }
+
+    #[test]
+    fn parses_content_length_only_when_valid() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(content_length(&headers), None);
+
+        headers.insert(header::CONTENT_LENGTH, HeaderValue::from_static("42"));
+        assert_eq!(content_length(&headers), Some(42));
+
+        headers.insert(
+            header::CONTENT_LENGTH,
+            HeaderValue::from_static("not-a-number"),
+        );
+        assert_eq!(content_length(&headers), None);
     }
 }

--- a/rust_stream/src/main.rs
+++ b/rust_stream/src/main.rs
@@ -131,11 +131,22 @@ async fn main() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
+    use std::{
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::{Duration, Instant},
+    };
 
     use axum::body::to_bytes;
+    use axum::body::Body;
     use axum::extract::{Path, State};
     use axum::http::{header, StatusCode};
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+    use axum::{Json, Router};
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 
     use super::*;
     use crate::cache::{CachedValue, SegmentCache};
@@ -145,6 +156,10 @@ mod tests {
     const TEST_MANIFEST_ADDRESS: &str = "test-manifest";
 
     fn test_state(catalog_bootstrap_address: Option<&str>) -> AppState {
+        test_state_with_antd(catalog_bootstrap_address, "http://127.0.0.1:0")
+    }
+
+    fn test_state_with_antd(catalog_bootstrap_address: Option<&str>, antd_url: &str) -> AppState {
         let cache_config = CacheConfig {
             catalog_ttl: Duration::from_secs(60),
             manifest_ttl: Duration::from_secs(60),
@@ -153,7 +168,7 @@ mod tests {
         };
 
         AppState {
-            antd: AntdRestClient::new("http://127.0.0.1:0").unwrap(),
+            antd: AntdRestClient::new(antd_url).unwrap(),
             catalog_state_path: env::temp_dir().join(format!(
                 "rust_stream_missing_catalog_{}.json",
                 std::process::id()
@@ -215,6 +230,76 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Default)]
+    struct MockAntdState {
+        catalog_requests: Arc<AtomicUsize>,
+        manifest_requests: Arc<AtomicUsize>,
+        segment_requests: Arc<AtomicUsize>,
+    }
+
+    async fn spawn_stream_mock_antd(state: MockAntdState) -> String {
+        let app = Router::new()
+            .route("/health", get(mock_health))
+            .route("/v1/data/public/:address", get(mock_data_get_public))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    async fn mock_health() -> Json<serde_json::Value> {
+        Json(serde_json::json!({
+            "status": "ok",
+            "network": "mocknet",
+        }))
+    }
+
+    async fn mock_data_get_public(
+        State(state): State<MockAntdState>,
+        Path(address): Path<String>,
+    ) -> axum::response::Response<Body> {
+        let bytes = match address.as_str() {
+            TEST_CATALOG_ADDRESS => {
+                state.catalog_requests.fetch_add(1, Ordering::Relaxed);
+                serde_json::to_vec(&serde_json::json!({
+                    "videos": [{
+                        "id": "video-1",
+                        "manifest_address": TEST_MANIFEST_ADDRESS
+                    }]
+                }))
+                .unwrap()
+            }
+            TEST_MANIFEST_ADDRESS => {
+                state.manifest_requests.fetch_add(1, Ordering::Relaxed);
+                serde_json::to_vec(&serde_json::json!({
+                    "id": "video-1",
+                    "status": "ready",
+                    "variants": [{
+                        "resolution": "720p",
+                        "segment_duration": 4.0,
+                        "segments": [{
+                            "segment_index": 0,
+                            "autonomi_address": "segment-0",
+                            "duration": 3.0
+                        }]
+                    }]
+                }))
+                .unwrap()
+            }
+            "segment-0" => {
+                state.segment_requests.fetch_add(1, Ordering::Relaxed);
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                b"segment bytes".to_vec()
+            }
+            _ => return (StatusCode::NOT_FOUND, "unknown address").into_response(),
+        };
+
+        Json(serde_json::json!({ "data": BASE64.encode(bytes) })).into_response()
+    }
+
     #[test]
     fn segment_cache_evicts_least_recently_used_entries() {
         let mut cache = SegmentCache::new(6, Duration::from_secs(60));
@@ -273,6 +358,94 @@ mod tests {
             body.as_ref(),
             b"#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:5\n#EXT-X-MEDIA-SEQUENCE:0\n#EXTINF:3.200,\n/stream/video-1/720p/0.ts\n#EXTINF:4.400,\n/stream/video-1/720p/1.ts\n#EXT-X-ENDLIST\n"
         );
+    }
+
+    #[tokio::test]
+    async fn hls_routes_fetch_catalog_manifest_and_segment_from_mock_antd() {
+        let mock_state = MockAntdState::default();
+        let base_url = spawn_stream_mock_antd(mock_state.clone()).await;
+        let state = test_state_with_antd(Some(TEST_CATALOG_ADDRESS), &base_url);
+
+        let playlist = routes::hls_manifest(
+            State(state.clone()),
+            Path(("video-1".to_string(), "720p".to_string())),
+        )
+        .await;
+        assert_eq!(playlist.status(), StatusCode::OK);
+        let body = to_bytes(playlist.into_body(), usize::MAX).await.unwrap();
+        assert!(std::str::from_utf8(body.as_ref())
+            .unwrap()
+            .contains("/stream/video-1/720p/0.ts"));
+
+        let first_segment = routes::hls_segment(
+            State(state.clone()),
+            Path((
+                "video-1".to_string(),
+                "720p".to_string(),
+                "0.ts".to_string(),
+            )),
+        )
+        .await;
+        assert_eq!(first_segment.status(), StatusCode::OK);
+        let first_body = to_bytes(first_segment.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(first_body.as_ref(), b"segment bytes");
+
+        let cached_segment = routes::hls_segment(
+            State(state),
+            Path((
+                "video-1".to_string(),
+                "720p".to_string(),
+                "0.ts".to_string(),
+            )),
+        )
+        .await;
+        assert_eq!(cached_segment.status(), StatusCode::OK);
+
+        assert_eq!(mock_state.catalog_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(mock_state.manifest_requests.load(Ordering::Relaxed), 1);
+        assert_eq!(mock_state.segment_requests.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrent_segment_misses_are_coalesced_against_mock_antd() {
+        let mock_state = MockAntdState::default();
+        let base_url = spawn_stream_mock_antd(mock_state.clone()).await;
+        let state = test_state_with_antd(Some(TEST_CATALOG_ADDRESS), &base_url);
+        cache_catalog_and_manifest(
+            &state,
+            TEST_CATALOG_ADDRESS,
+            TEST_MANIFEST_ADDRESS,
+            ready_manifest(),
+        )
+        .await;
+
+        let first = routes::hls_segment(
+            State(state.clone()),
+            Path((
+                "video-1".to_string(),
+                "720p".to_string(),
+                "0.ts".to_string(),
+            )),
+        );
+        let second = routes::hls_segment(
+            State(state.clone()),
+            Path((
+                "video-1".to_string(),
+                "720p".to_string(),
+                "0.ts".to_string(),
+            )),
+        );
+        let (first, second) = tokio::join!(first, second);
+
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(second.status(), StatusCode::OK);
+        assert_eq!(mock_state.segment_requests.load(Ordering::Relaxed), 1);
+        assert!(state
+            .metrics
+            .render_prometheus()
+            .contains("autvid_stream_segment_fetch_coalesced_total{service=\"rust_stream\"} 1"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Summary**

Adds a broad unit and mock-integration test pass across the application, covering the reliability and streaming paths added during the modernization work.

**Changes**

- Added mock `antd` integration coverage for `rust_admin` wallet, health, data upload/download, file upload, retry, metrics, and invalid base64 behavior.
- Added `rust_stream` tests for catalog, manifest, playlist, segment fetching, cache behavior, and concurrent cache-miss coalescing.
- Added `rust_admin` unit tests for catalog state quarantine/write behavior, catalog privacy mapping, job recovery helpers, upload parsing, and media parsing/sorting helpers.
- Added `antd_service` tests for shared base64 decoding, payment mode parsing, and address validation.
- Added React tests for upload quote/upload failure handling and active-job polling behavior.

**Validation**

- `cargo fmt --all -- --check`
- `CARGO_BUILD_JOBS=1 cargo test --workspace`
- `CARGO_BUILD_JOBS=1 cargo clippy --workspace --all-targets -- -D warnings`
- `npm test -- --run`
- `npm run build`
- `make compose-config`

Note: the Vite build still emits the existing large `hls.js` chunk warning, but the build succeeds.