### PR TITLE
Improve Autonomi quote circuit diagnostics

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -163,6 +163,7 @@ impl Error for AutonomiHttpStatusError {}
 pub struct CircuitBreaker {
     consecutive_failures: AtomicUsize,
     opened_until_epoch_ms: AtomicU64,
+    last_retryable_error: Mutex<Option<String>>,
 }
 
 impl CircuitBreaker {
@@ -173,10 +174,20 @@ impl CircuitBreaker {
         let now = epoch_millis();
         let opened_until = self.opened_until_epoch_ms.load(Ordering::Relaxed);
         if opened_until > now {
-            anyhow::bail!(
-                "Autonomi request circuit is open for {}ms",
-                opened_until.saturating_sub(now)
-            );
+            let remaining_ms = opened_until.saturating_sub(now);
+            let last_retryable_error = self
+                .last_retryable_error
+                .lock()
+                .unwrap_or_else(|err| err.into_inner())
+                .clone();
+            if let Some(last_retryable_error) = last_retryable_error {
+                anyhow::bail!(
+                    "Autonomi request circuit is open for {}ms; last retryable error: {}",
+                    remaining_ms,
+                    last_retryable_error
+                );
+            }
+            anyhow::bail!("Autonomi request circuit is open for {}ms", remaining_ms);
         }
         Ok(())
     }
@@ -185,6 +196,10 @@ impl CircuitBreaker {
         if result.is_ok() {
             self.consecutive_failures.store(0, Ordering::Relaxed);
             self.opened_until_epoch_ms.store(0, Ordering::Relaxed);
+            *self
+                .last_retryable_error
+                .lock()
+                .unwrap_or_else(|err| err.into_inner()) = None;
             return;
         }
 
@@ -193,9 +208,17 @@ impl CircuitBreaker {
         };
         if !is_retryable_antd_error(err) {
             self.consecutive_failures.store(0, Ordering::Relaxed);
+            *self
+                .last_retryable_error
+                .lock()
+                .unwrap_or_else(|err| err.into_inner()) = None;
             return;
         }
 
+        *self
+            .last_retryable_error
+            .lock()
+            .unwrap_or_else(|err| err.into_inner()) = Some(err.to_string());
         let failures = self
             .consecutive_failures
             .fetch_add(1, Ordering::Relaxed)
@@ -503,6 +526,11 @@ mod tests {
         }
 
         assert!(breaker.check().is_err());
+        assert!(breaker
+            .check()
+            .unwrap_err()
+            .to_string()
+            .contains("last retryable error: GET /health failed"));
 
         let result: anyhow::Result<()> = Ok(());
         breaker.record_result(&result);

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -44,6 +44,39 @@ docker compose --env-file .env.production \
   logs --tail=200 rust_admin
 ```
 
+## Upload Quote Unavailable
+
+If the UI says `Autonomi request circuit is open`, `rust_admin` has already
+seen repeated retryable `antd` failures and is failing fast for about 30
+seconds. Check the first `antd` error in the message or logs; common causes are
+`Found 0 peers, need 7`, low peer count, or a timed-out write quote.
+
+For the local Compose devnet, confirm the gateway can see peers and return a
+small write quote:
+
+```bash
+docker compose --env-file .env.local \
+  -f docker-compose.yml \
+  -f docker-compose.local.yml \
+  exec rust_admin curl -fsS http://antd:8082/health
+
+docker compose --env-file .env.local \
+  -f docker-compose.yml \
+  -f docker-compose.local.yml \
+  exec rust_admin sh -ceu '
+    token="$(cat "$ANTD_INTERNAL_TOKEN_FILE" 2>/dev/null || printf %s "$ANTD_INTERNAL_TOKEN")"
+    curl -fsS -X POST \
+      -H "Authorization: Bearer $token" \
+      -H "Content-Type: application/json" \
+      -d "{\"data\":\"aGV5\"}" \
+      http://antd:8082/v1/data/cost
+  '
+```
+
+If local `/health` reports `peer_count: 0`, the local devnet/gateway is stale.
+Restarting `antd` usually rebuilds the test network, but the default
+`ANT_DEVNET_RESET_ON_START=true` deletes local devnet data.
+
 ## antd Peer Count Low
 
 The gateway can be healthy before enough Autonomi peers are reachable for

--- a/rust_admin/src/antd_client.rs
+++ b/rust_admin/src/antd_client.rs
@@ -542,6 +542,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mock_antd_cost_estimate_open_circuit_preserves_last_error() {
+        let mock_state = MockAntdState::default();
+        mock_state
+            .cost_failures_remaining
+            .store(10, Ordering::Relaxed);
+        let base_url = spawn_mock_antd(mock_state.clone()).await;
+        let client =
+            AntdRestClient::new(&base_url, 5.0, Arc::new(AdminMetrics::default()), None).unwrap();
+
+        let first_error = match client.data_cost_for_size(3).await {
+            Ok(_) => panic!("expected persistent cost estimate failure"),
+            Err(err) => err,
+        };
+        assert!(first_error.to_string().contains("cost unavailable"));
+
+        let second_error = match client.data_cost_for_size(3).await {
+            Ok(_) => panic!("expected circuit-open cost estimate failure"),
+            Err(err) => err,
+        };
+        let message = second_error.to_string();
+        assert!(message.contains("Autonomi request circuit is open"));
+        assert!(message.contains("last retryable error"));
+        assert!(message.contains("POST /v1/data/cost failed: 503 Service Unavailable"));
+        assert!(message.contains("cost unavailable"));
+        assert_eq!(mock_state.cost_requests.load(Ordering::Relaxed), 5);
+    }
+
+    #[tokio::test]
     async fn mock_antd_client_rejects_invalid_base64_downloads() {
         let base_url = spawn_mock_antd(MockAntdState::default()).await;
         let client =


### PR DESCRIPTION
## Summary
- preserve the last retryable Autonomi error when the request circuit is open
- add regression coverage for repeated cost quote failures opening the circuit
- document local and production quote troubleshooting probes

## Verification
- cargo fmt --check
- cargo test -p autvid_common
- cargo test -p rust_admin mock_antd_cost_estimate
- npm test -- --run src/__tests__/upload.test.tsx src/__tests__/apiClient.test.ts