### PR TITLE
Fix playback seek after quality change

### DIFF
--- a/react_frontend/src/__tests__/playback.test.tsx
+++ b/react_frontend/src/__tests__/playback.test.tsx
@@ -162,6 +162,7 @@ test("passes the current playback position to hls.js when changing resolution", 
       on: vi.fn((eventName, handler) => {
         hlsInstance.handlers[eventName] = handler;
       }),
+      startLoad: vi.fn(),
     };
     hlsInstances.push(hlsInstance);
     return hlsInstance;
@@ -214,6 +215,76 @@ test("passes the current playback position to hls.js when changing resolution", 
   });
 
   expect(video.currentTime).toBe(0);
+  expect(video.play).toHaveBeenCalled();
+});
+
+test("honors a manual scrub to the beginning while hls.js reloads after a resolution change", async () => {
+  Hls.isSupported.mockReturnValue(true);
+  const hlsInstances = [];
+  Hls.mockImplementation(() => {
+    const hlsInstance = {
+      attachMedia: vi.fn((media) => {
+        hlsInstance.media = media;
+      }),
+      destroy: vi.fn(() => {
+        if (hlsInstance.media) hlsInstance.media.currentTime = 0;
+      }),
+      handlers: {},
+      loadSource: vi.fn(),
+      media: null,
+      on: vi.fn((eventName, handler) => {
+        hlsInstance.handlers[eventName] = handler;
+      }),
+      startLoad: vi.fn(),
+    };
+    hlsInstances.push(hlsInstance);
+    return hlsInstance;
+  });
+  const publicVideo = {
+    created_at: "2026-04-27T12:00:00Z",
+    description: "Public description only",
+    id: "pub-hls-scrub-start",
+    original_filename: "",
+    status: "published",
+    title: "HLS scrub stream",
+  };
+  setupGetRoutes({
+    publicVideos: [publicVideo],
+    details: {
+      "/api/videos/pub-hls-scrub-start": {
+        ...publicVideo,
+        manifest_address: null,
+        variants: [
+          { id: "variant-720", resolution: "720p", segment_count: 20 },
+          { id: "variant-480", resolution: "480p", segment_count: 20 },
+        ],
+      },
+    },
+  });
+
+  await renderApp();
+  await waitFor(() => expect(text()).toContain("HLS scrub stream"));
+  await click(findButton("HLS scrub stream"));
+
+  const video = container.querySelector("video");
+  Object.defineProperties(video, {
+    currentTime: { configurable: true, writable: true, value: 15 },
+    ended: { configurable: true, value: false },
+    paused: { configurable: true, value: false },
+    play: { configurable: true, value: vi.fn(() => Promise.resolve()) },
+  });
+
+  await click(container.querySelector(".quality-toggle"));
+  await click(findButton("480p"));
+
+  await act(async () => {
+    video.currentTime = 0;
+    video.dispatchEvent(new Event("seeking"));
+    hlsInstances[1].handlers[Hls.Events.MANIFEST_PARSED]();
+  });
+
+  expect(Hls.mock.calls[1][0]).toMatchObject({ autoStartLoad: false, startPosition: 15 });
+  expect(hlsInstances[1].startLoad).toHaveBeenCalledWith(0);
   expect(video.play).toHaveBeenCalled();
 });
 
@@ -289,6 +360,69 @@ test("waits for native HLS duration before seeking after a resolution change", a
   });
 
   expect(video.currentTime).toBe(7);
+  expect(video.play).toHaveBeenCalled();
+});
+
+test("honors a manual scrub to the beginning while native HLS reloads after a resolution change", async () => {
+  Hls.isSupported.mockReturnValue(false);
+  vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((type) => (
+    type === "application/vnd.apple.mpegurl" ? "maybe" : ""
+  ));
+  vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(function load() {
+    this.currentTime = 0;
+  });
+  const publicVideo = {
+    created_at: "2026-04-27T12:00:00Z",
+    description: "Public description only",
+    id: "pub-native-scrub-start",
+    original_filename: "",
+    status: "published",
+    title: "Native scrub stream",
+  };
+  setupGetRoutes({
+    publicVideos: [publicVideo],
+    details: {
+      "/api/videos/pub-native-scrub-start": {
+        ...publicVideo,
+        manifest_address: null,
+        variants: [
+          { id: "variant-720", resolution: "720p", segment_count: 20 },
+          { id: "variant-480", resolution: "480p", segment_count: 20 },
+        ],
+      },
+    },
+  });
+
+  await renderApp();
+  await waitFor(() => expect(text()).toContain("Native scrub stream"));
+  await click(findButton("Native scrub stream"));
+
+  const video = container.querySelector("video");
+  let currentTime = 15;
+  Object.defineProperties(video, {
+    currentTime: {
+      configurable: true,
+      get: () => currentTime,
+      set: (value) => {
+        currentTime = value;
+      },
+    },
+    duration: { configurable: true, value: 1 },
+    ended: { configurable: true, value: false },
+    paused: { configurable: true, value: false },
+    play: { configurable: true, value: vi.fn(() => Promise.resolve()) },
+  });
+
+  await click(container.querySelector(".quality-toggle"));
+  await click(findButton("480p"));
+
+  await act(async () => {
+    video.currentTime = 0;
+    video.dispatchEvent(new Event("seeking"));
+    video.dispatchEvent(new Event("loadedmetadata"));
+  });
+
+  expect(video.currentTime).toBe(0);
   expect(video.play).toHaveBeenCalled();
 });
 

--- a/react_frontend/src/components/VideoPlayer.tsx
+++ b/react_frontend/src/components/VideoPlayer.tsx
@@ -105,35 +105,61 @@ export default function VideoPlayer({
     let active = true;
     let cleanupPlayback = () => {};
     const { currentTime: resumeAt, shouldResume } = playbackStateRef.current;
+    let pendingResumeAt = resumeAt;
+    let restorePending = resumeAt > 0;
+    let hlsManifestParsed = false;
     let resumedAfterRestore = false;
+    const readCurrentTime = () => (
+      Number.isFinite(video.currentTime) ? video.currentTime : 0
+    );
+    const syncPendingSeek = () => {
+      if (!restorePending) return;
+      pendingResumeAt = readCurrentTime();
+      playbackStateRef.current = { currentTime: pendingResumeAt, shouldResume };
+
+      const hls = hlsRef.current;
+      if (hls && hlsManifestParsed) {
+        hls.startLoad(pendingResumeAt > 0 ? pendingResumeAt : 0);
+      }
+    };
+    const finishRestore = () => {
+      restorePending = false;
+      video.removeEventListener("canplay", finishRestore);
+      video.removeEventListener("playing", finishRestore);
+    };
     const resumePlayback = () => {
       if (shouldResume && !resumedAfterRestore) {
         resumedAfterRestore = true;
         video.play().catch(() => {});
       }
     };
+    const removeNativeRestoreListeners = () => {
+      video.removeEventListener("canplay", restoreNativePlayback);
+      video.removeEventListener("durationchange", restoreNativePlayback);
+      video.removeEventListener("loadeddata", restoreNativePlayback);
+      video.removeEventListener("loadedmetadata", restoreNativePlayback);
+      video.removeEventListener("seeking", syncPendingSeek);
+    };
     const restoreNativePlayback = () => {
-      if (resumeAt > 0) {
+      if (pendingResumeAt > 0) {
         const duration = video.duration;
         if (
           Number.isFinite(duration) &&
-          duration <= resumeAt + RESUME_DURATION_TOLERANCE_SECONDS
+          duration <= pendingResumeAt + RESUME_DURATION_TOLERANCE_SECONDS
         ) {
           return;
         }
 
         try {
-          video.currentTime = resumeAt;
+          video.currentTime = pendingResumeAt;
         } catch {
           return;
         }
       }
 
+      finishRestore();
       resumePlayback();
-      video.removeEventListener("canplay", restoreNativePlayback);
-      video.removeEventListener("durationchange", restoreNativePlayback);
-      video.removeEventListener("loadeddata", restoreNativePlayback);
-      video.removeEventListener("loadedmetadata", restoreNativePlayback);
+      removeNativeRestoreListeners();
     };
 
     const attachNativePlayback = () => {
@@ -144,14 +170,12 @@ export default function VideoPlayer({
       video.addEventListener("durationchange", restoreNativePlayback);
       video.addEventListener("loadeddata", restoreNativePlayback);
       video.addEventListener("loadedmetadata", restoreNativePlayback);
+      video.addEventListener("seeking", syncPendingSeek);
       video.addEventListener("error", onNativePlaybackError, { once: true });
       video.src = src;
       video.load();
       cleanupPlayback = () => {
-        video.removeEventListener("canplay", restoreNativePlayback);
-        video.removeEventListener("durationchange", restoreNativePlayback);
-        video.removeEventListener("loadeddata", restoreNativePlayback);
-        video.removeEventListener("loadedmetadata", restoreNativePlayback);
+        removeNativeRestoreListeners();
         video.removeEventListener("error", onNativePlaybackError);
       };
     };
@@ -164,13 +188,23 @@ export default function VideoPlayer({
         const hls = new Hls({
           enableWorker: true,
           ...HLS_RETRY_CONFIG,
+          autoStartLoad: resumeAt > 0 ? false : true,
           lowLatencyMode: false,
           startPosition: resumeAt > 0 ? resumeAt : -1,
         });
         hlsRef.current = hls;
         hls.loadSource(src);
         hls.attachMedia(video);
-        hls.on(Hls.Events.MANIFEST_PARSED, resumePlayback);
+        video.addEventListener("canplay", finishRestore);
+        video.addEventListener("playing", finishRestore);
+        video.addEventListener("seeking", syncPendingSeek);
+        hls.on(Hls.Events.MANIFEST_PARSED, () => {
+          hlsManifestParsed = true;
+          if (restorePending) {
+            hls.startLoad(pendingResumeAt > 0 ? pendingResumeAt : 0);
+          }
+          resumePlayback();
+        });
         hls.on(Hls.Events.ERROR, (_event, data) => {
           if (data?.fatal) {
             if (
@@ -195,6 +229,9 @@ export default function VideoPlayer({
           }
         });
         cleanupPlayback = () => {
+          video.removeEventListener("canplay", finishRestore);
+          video.removeEventListener("playing", finishRestore);
+          video.removeEventListener("seeking", syncPendingSeek);
           hls.destroy();
           hlsRef.current = null;
         };


### PR DESCRIPTION
## Summary
- Preserve user scrub position while a quality-change reload is restoring playback
- Start hls.js loading from the scrubbed position once the new manifest is ready
- Add hls.js and native-HLS regression tests for scrubbing back to the beginning after a resolution change

## Testing
- npm test -- src/__tests__/playback.test.tsx
- npm test
- npm run lint
- npm run build