### PR TITLE
Improve native HLS seek recovery

### DIFF
--- a/react_frontend/src/__tests__/playback.test.tsx
+++ b/react_frontend/src/__tests__/playback.test.tsx
@@ -426,6 +426,95 @@ test("honors a manual scrub to the beginning while native HLS reloads after a re
   expect(video.play).toHaveBeenCalled();
 });
 
+test("resumes native HLS after a scrub near the beginning once a resolution change has settled", async () => {
+  Hls.isSupported.mockReturnValue(false);
+  vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((type) => (
+    type === "application/vnd.apple.mpegurl" ? "maybe" : ""
+  ));
+  vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(function load() {
+    this.currentTime = 0;
+  });
+  const publicVideo = {
+    created_at: "2026-04-27T12:00:00Z",
+    description: "Public description only",
+    id: "pub-native-settled-scrub",
+    original_filename: "",
+    status: "published",
+    title: "Native settled scrub stream",
+  };
+  setupGetRoutes({
+    publicVideos: [publicVideo],
+    details: {
+      "/api/videos/pub-native-settled-scrub": {
+        ...publicVideo,
+        manifest_address: null,
+        variants: [
+          { id: "variant-720", resolution: "720p", segment_count: 20 },
+          { id: "variant-480", resolution: "480p", segment_count: 20 },
+        ],
+      },
+    },
+  });
+
+  await renderApp();
+  await waitFor(() => expect(text()).toContain("Native settled scrub stream"));
+  await click(findButton("Native settled scrub stream"));
+
+  const video = container.querySelector("video");
+  let currentTime = 15;
+  let paused = false;
+  let seeking = false;
+  Object.defineProperties(video, {
+    currentTime: {
+      configurable: true,
+      get: () => currentTime,
+      set: (value) => {
+        currentTime = value;
+      },
+    },
+    duration: { configurable: true, value: 20 },
+    ended: { configurable: true, value: false },
+    paused: {
+      configurable: true,
+      get: () => paused,
+    },
+    play: {
+      configurable: true,
+      value: vi.fn(() => {
+        paused = false;
+        return Promise.resolve();
+      }),
+    },
+    readyState: { configurable: true, value: 1 },
+    seeking: {
+      configurable: true,
+      get: () => seeking,
+    },
+  });
+
+  await click(container.querySelector(".quality-toggle"));
+  await click(findButton("480p"));
+  await act(async () => {
+    video.dispatchEvent(new Event("loadedmetadata"));
+    video.dispatchEvent(new Event("playing"));
+  });
+  const play = video.play as ReturnType<typeof vi.fn>;
+  play.mockClear();
+
+  await act(async () => {
+    currentTime = 1.25;
+    paused = true;
+    seeking = true;
+    video.dispatchEvent(new Event("pause"));
+    video.dispatchEvent(new Event("seeking"));
+    seeking = false;
+    video.dispatchEvent(new Event("seeked"));
+  });
+
+  expect(video.currentTime).toBe(1.25);
+  expect(play).toHaveBeenCalled();
+});
+
 test("closes the playback resolution menu when the pointer leaves it", async () => {
   const publicVideo = {
     created_at: "2026-04-27T12:00:00Z",

--- a/react_frontend/src/components/VideoPlayer.tsx
+++ b/react_frontend/src/components/VideoPlayer.tsx
@@ -18,6 +18,7 @@ const HLS_RETRY_CONFIG = {
   manifestLoadingRetryDelay: 500,
 };
 const HLS_FATAL_RECOVERY_ATTEMPTS = 1;
+const MEDIA_HAVE_FUTURE_DATA = 3;
 
 interface PlaybackState {
   currentTime: number;
@@ -43,6 +44,7 @@ export default function VideoPlayer({
   const hlsRef = useRef<Hls | null>(null);
   const controlsIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const playbackStateRef = useRef<PlaybackState>({ currentTime: 0, shouldResume: false });
+  const playbackIntentRef = useRef(false);
   const [qualityOpen, setQualityOpen] = useState(false);
   const [controlsActive, setControlsActive] = useState(true);
   const [playbackError, setPlaybackError] = useState("");
@@ -82,15 +84,18 @@ export default function VideoPlayer({
     scheduleControlsIdleHide();
   }, [scheduleControlsIdleHide]);
 
+  const capturePlaybackStateFromVideo = useCallback((video: HTMLVideoElement) => {
+    playbackStateRef.current = {
+      currentTime: Number.isFinite(video.currentTime) ? video.currentTime : 0,
+      shouldResume: playbackIntentRef.current || (!video.paused && !video.ended),
+    };
+  }, []);
+
   const capturePlaybackState = useCallback(() => {
     const video = videoRef.current;
     if (!video) return;
-
-    playbackStateRef.current = {
-      currentTime: Number.isFinite(video.currentTime) ? video.currentTime : 0,
-      shouldResume: !video.paused && !video.ended,
-    };
-  }, []);
+    capturePlaybackStateFromVideo(video);
+  }, [capturePlaybackStateFromVideo]);
 
   const handleResolutionChange = useCallback((nextResolution: string) => {
     capturePlaybackState();
@@ -109,9 +114,46 @@ export default function VideoPlayer({
     let restorePending = resumeAt > 0;
     let hlsManifestParsed = false;
     let resumedAfterRestore = false;
+    let nativeSeekRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+    let nativeSeekResumeAt = 0;
+    let nativeSeekShouldResume = false;
     const readCurrentTime = () => (
       Number.isFinite(video.currentTime) ? video.currentTime : 0
     );
+    const clearNativeSeekRecoveryTimer = () => {
+      if (nativeSeekRecoveryTimer) {
+        clearTimeout(nativeSeekRecoveryTimer);
+        nativeSeekRecoveryTimer = null;
+      }
+    };
+    const wantsPlayback = () => (
+      playbackIntentRef.current || (!video.paused && !video.ended)
+    );
+    const requestPlayback = () => {
+      playbackIntentRef.current = true;
+      video.play().catch(() => {});
+    };
+    const scheduleNativeSeekRecovery = () => {
+      clearNativeSeekRecoveryTimer();
+      if (!nativeSeekShouldResume) return;
+
+      nativeSeekRecoveryTimer = setTimeout(() => {
+        nativeSeekRecoveryTimer = null;
+        if (!active || !nativeSeekShouldResume || video.ended) return;
+
+        if (video.paused || video.readyState < MEDIA_HAVE_FUTURE_DATA) {
+          try {
+            if (Math.abs(readCurrentTime() - nativeSeekResumeAt) > RESUME_DURATION_TOLERANCE_SECONDS) {
+              video.currentTime = nativeSeekResumeAt;
+            }
+          } catch {
+            // Safari can reject seeks while native HLS is swapping internal buffers.
+          }
+          requestPlayback();
+          scheduleNativeSeekRecovery();
+        }
+      }, 750);
+    };
     const syncPendingSeek = () => {
       if (!restorePending) return;
       pendingResumeAt = readCurrentTime();
@@ -130,7 +172,7 @@ export default function VideoPlayer({
     const resumePlayback = () => {
       if (shouldResume && !resumedAfterRestore) {
         resumedAfterRestore = true;
-        video.play().catch(() => {});
+        requestPlayback();
       }
     };
     const removeNativeRestoreListeners = () => {
@@ -166,17 +208,62 @@ export default function VideoPlayer({
       const onNativePlaybackError = () => {
         setPlaybackError("Playback failed because the video segments could not be loaded.");
       };
+      const rememberNativeSeekIntent = () => {
+        nativeSeekResumeAt = readCurrentTime();
+        nativeSeekShouldResume = restorePending
+          ? wantsPlayback() || shouldResume
+          : wantsPlayback();
+        if (nativeSeekShouldResume) scheduleNativeSeekRecovery();
+      };
+      const resumeAfterNativeSeek = () => {
+        nativeSeekResumeAt = readCurrentTime();
+        if (!nativeSeekShouldResume) return;
+        requestPlayback();
+        scheduleNativeSeekRecovery();
+      };
+      const finishNativeSeekRecovery = () => {
+        nativeSeekShouldResume = false;
+        clearNativeSeekRecoveryTimer();
+      };
+      const recoverNativeSeekStall = () => {
+        if (!nativeSeekShouldResume && !wantsPlayback()) return;
+        nativeSeekResumeAt = readCurrentTime();
+        nativeSeekShouldResume = true;
+        scheduleNativeSeekRecovery();
+      };
+      const cancelNativeSeekRecovery = () => {
+        if (video.seeking) return;
+        nativeSeekShouldResume = false;
+        clearNativeSeekRecoveryTimer();
+      };
       video.addEventListener("canplay", restoreNativePlayback);
       video.addEventListener("durationchange", restoreNativePlayback);
       video.addEventListener("loadeddata", restoreNativePlayback);
       video.addEventListener("loadedmetadata", restoreNativePlayback);
       video.addEventListener("seeking", syncPendingSeek);
+      video.addEventListener("seeking", rememberNativeSeekIntent);
+      video.addEventListener("seeked", resumeAfterNativeSeek);
+      video.addEventListener("canplay", resumeAfterNativeSeek);
+      video.addEventListener("playing", finishNativeSeekRecovery);
+      video.addEventListener("pause", cancelNativeSeekRecovery);
+      video.addEventListener("stalled", recoverNativeSeekStall);
+      video.addEventListener("waiting", recoverNativeSeekStall);
       video.addEventListener("error", onNativePlaybackError, { once: true });
       video.src = src;
       video.load();
       cleanupPlayback = () => {
+        clearNativeSeekRecoveryTimer();
         removeNativeRestoreListeners();
+        video.removeEventListener("seeking", rememberNativeSeekIntent);
+        video.removeEventListener("seeked", resumeAfterNativeSeek);
+        video.removeEventListener("canplay", resumeAfterNativeSeek);
+        video.removeEventListener("playing", finishNativeSeekRecovery);
+        video.removeEventListener("pause", cancelNativeSeekRecovery);
+        video.removeEventListener("stalled", recoverNativeSeekStall);
+        video.removeEventListener("waiting", recoverNativeSeekStall);
         video.removeEventListener("error", onNativePlaybackError);
+        video.removeAttribute("src");
+        video.load();
       };
     };
 
@@ -249,32 +336,38 @@ export default function VideoPlayer({
 
     return () => {
       active = false;
-      capturePlaybackState();
+      capturePlaybackStateFromVideo(video);
       cleanupPlayback();
       hlsRef.current = null;
     };
-  }, [capturePlaybackState, src]);
+  }, [capturePlaybackStateFromVideo, src]);
 
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return undefined;
 
     const handlePlay = () => {
+      playbackIntentRef.current = true;
       setControlsActive(true);
       scheduleControlsIdleHide();
     };
     const handlePause = () => {
+      if (!video.seeking) playbackIntentRef.current = false;
       clearControlsIdleTimer();
       setControlsActive(true);
+    };
+    const handleEnded = () => {
+      playbackIntentRef.current = false;
+      handlePause();
     };
 
     video.addEventListener("play", handlePlay);
     video.addEventListener("pause", handlePause);
-    video.addEventListener("ended", handlePause);
+    video.addEventListener("ended", handleEnded);
     return () => {
       video.removeEventListener("play", handlePlay);
       video.removeEventListener("pause", handlePause);
-      video.removeEventListener("ended", handlePause);
+      video.removeEventListener("ended", handleEnded);
     };
   }, [clearControlsIdleTimer, scheduleControlsIdleHide]);
 

--- a/rust_stream/src/hls.rs
+++ b/rust_stream/src/hls.rs
@@ -104,7 +104,7 @@ where
         .fold(variant.segment_duration, f64::max)
         .ceil() as u64;
     let mut m3u8 = format!(
-        "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:{target_duration}\n#EXT-X-MEDIA-SEQUENCE:0\n"
+        "#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-PLAYLIST-TYPE:VOD\n#EXT-X-INDEPENDENT-SEGMENTS\n#EXT-X-TARGETDURATION:{target_duration}\n#EXT-X-MEDIA-SEQUENCE:0\n"
     );
 
     for seg in &variant.segments {

--- a/rust_stream/src/main.rs
+++ b/rust_stream/src/main.rs
@@ -396,7 +396,7 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(
             body.as_ref(),
-            b"#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:5\n#EXT-X-MEDIA-SEQUENCE:0\n#EXTINF:3.200,\n/stream/video-1/720p/0.ts\n#EXTINF:4.400,\n/stream/video-1/720p/1.ts\n#EXT-X-ENDLIST\n"
+            b"#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-PLAYLIST-TYPE:VOD\n#EXT-X-INDEPENDENT-SEGMENTS\n#EXT-X-TARGETDURATION:5\n#EXT-X-MEDIA-SEQUENCE:0\n#EXTINF:3.200,\n/stream/video-1/720p/0.ts\n#EXTINF:4.400,\n/stream/video-1/720p/1.ts\n#EXT-X-ENDLIST\n"
         );
     }
 
@@ -513,7 +513,7 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         assert_eq!(
             body.as_ref(),
-            b"#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-TARGETDURATION:5\n#EXT-X-MEDIA-SEQUENCE:0\n#EXTINF:3.200,\n/stream/manifest/test-manifest/720p/0.ts\n#EXTINF:4.400,\n/stream/manifest/test-manifest/720p/1.ts\n#EXT-X-ENDLIST\n"
+            b"#EXTM3U\n#EXT-X-VERSION:3\n#EXT-X-PLAYLIST-TYPE:VOD\n#EXT-X-INDEPENDENT-SEGMENTS\n#EXT-X-TARGETDURATION:5\n#EXT-X-MEDIA-SEQUENCE:0\n#EXTINF:3.200,\n/stream/manifest/test-manifest/720p/0.ts\n#EXTINF:4.400,\n/stream/manifest/test-manifest/720p/1.ts\n#EXT-X-ENDLIST\n"
         );
     }
 


### PR DESCRIPTION
## Summary
- Add native-HLS seek recovery so Safari resumes playback after scrubbing near the beginning following a quality change
- Keep playback intent through native control seeks without auto-resuming intentionally paused playback
- Mark generated HLS playlists as VOD with independent segments for more reliable browser seeking

## Testing
- npm test -- src/__tests__/playback.test.tsx
- npm test
- npm run lint
- npm run build
- cargo test -p rust_stream hls_manifest
- cargo test -p rust_stream

## Devnet
- Rebuilt and recreated rust_stream and react_frontend with .env.local/local compose overlay
- Restarted nginx_proxy
- Verified rust_stream has ANTD_INTERNAL_TOKEN again and the playlist returns EXT-X-PLAYLIST-TYPE:VOD plus EXT-X-INDEPENDENT-SEGMENTS