### PR TITLE
Document catalog state and add docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Compose remains the supported deployment runtime. The repo also documents the
 service boundary used by the native launcher so local packages can reuse the
 same Rust admin, Rust stream, `antd`, endpoint, and app-data contracts without
 changing current containers. See
+[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md),
 [`docs/RUNTIME_MODES.md`](docs/RUNTIME_MODES.md) and the machine-readable
 [`docs/runtime-contract.example.json`](docs/runtime-contract.example.json).
 
@@ -383,6 +384,7 @@ production and operations overlays live in separate docs:
 - [Image publishing](docs/IMAGE_PUBLISHING.md) covers GHCR image builds and tags.
 - [Backup sidecar](docs/BACKUP_SIDECAR.md) covers scheduled SQLite/catalog backups.
 - [Observability](docs/OBSERVABILITY.md) covers Prometheus, Grafana, and Alertmanager.
+- [Docs index](docs/README.md) links the full operations and architecture docs.
 
 ---
 
@@ -528,7 +530,7 @@ autonomi-video-management/
 │   ├── Dockerfile              # Self-contained local ant-devnet + antd testnet
 │   └── start-local-devnet.sh
 ├── common/
-│   └── src/lib.rs              # Shared Rust helpers used by multiple services
+│   └── src/                    # Shared Rust helpers split by metrics, HTTP, runtime, and circuit-breaker concerns
 ├── rust_admin/
 │   ├── Dockerfile
 │   ├── Cargo.toml
@@ -554,6 +556,8 @@ autonomi-video-management/
 │   └── conf.d/default.conf     # Local HTTP reverse proxy
 ├── standalone_launcher/        # Linux/macOS local web launcher
 ├── docs/
+│   ├── README.md               # Documentation index
+│   ├── ARCHITECTURE.md         # Durable workflow and service boundary notes
 │   ├── DEPLOYMENT.md           # Production deployment guide
 │   ├── RUNTIME_MODES.md        # Compose and standalone runtime boundaries
 │   └── runtime-contract.example.json # Example native host endpoint/path contract

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,75 @@
+# Architecture
+
+Autonomi Video Management keeps the service boundaries deliberately boring:
+the browser talks to Nginx, Nginx routes admin API requests to `rust_admin`,
+playback requests to `rust_stream`, and both Rust services talk to the local
+`antd` gateway instead of joining the Autonomi peer network directly.
+
+## Service Boundaries
+
+| Service | Responsibility |
+|---|---|
+| `react_frontend` | Upload, approval, publication, catalog, and playback UI |
+| `nginx` | Browser-facing reverse proxy, security headers, request IDs, and rate limits |
+| `rust_admin` | Auth, upload intake, FFmpeg transcoding, durable jobs, quotes, uploads, manifests, and catalog publication |
+| `rust_stream` | Public HLS playlists and segment proxying from Autonomi |
+| `antd` | REST gateway for Autonomi connectivity, payment, storage, and retrieval |
+| SQLite | Local admin metadata, auth sessions, durable jobs, and recovery bookkeeping |
+| Autonomi | Durable playback objects: segments, manifests, and published catalogs |
+
+The frontend never receives private segment addresses from public endpoints.
+Public playback goes through `rust_stream`, which resolves the current catalog
+and manifest before streaming segment bytes.
+
+## Upload And Approval Flow
+
+1. `rust_admin` streams the source upload to app data and records the video row,
+   requested renditions, source path, and durable job input in SQLite.
+2. A durable processing job probes the source, transcodes HLS renditions with
+   FFmpeg, records variant and segment rows, and builds a final quote from the
+   real bytes on disk.
+3. The job pauses in `awaiting_approval` until an admin approves the final
+   quote before storage payment is committed.
+4. A durable upload job streams every segment, and optionally the original
+   source file, through the `antd` file endpoint.
+5. Upload verification reads data back before the video is marked `ready`.
+6. `rust_admin` stores a video manifest on Autonomi, then catalog publication
+   writes portable catalog documents for public and all-ready-video views.
+
+The `rust_admin` durable queue currently stores three job kinds:
+`process_video`, `upload_video`, and `publish_catalog`. On startup, the admin
+service leases eligible pending, processing, uploading, and catalog-publish
+work from SQLite.
+Interrupted transcodes restart from the saved source file. Interrupted uploads
+reuse persisted segment rows and skip segments that already have Autonomi
+addresses.
+
+## Catalog State
+
+Catalog state is intentionally dual-written:
+
+- SQLite stores mutable admin metadata and durable job state.
+- Autonomi stores durable manifest and catalog documents for playback.
+- The JSON catalog state file stores the latest catalog addresses and decoded
+  snapshots as a local bootstrap and recovery aid.
+
+The JSON file is not legacy state. It lets `rust_stream` and restarted stacks
+find the latest catalog address without requiring a fresh admin query, and it
+gives operators a small inspectable recovery artifact alongside the SQLite
+database. Invalid JSON is quarantined to a `.broken` file rather than silently
+overwritten.
+
+## Reliability Posture
+
+The architecture keeps these safety rails on purpose:
+
+- SQLite-backed durable jobs with leases, attempts, retry backoff, and startup
+  recovery.
+- Upload verification before manifests and catalogs point at new data.
+- Catalog publication jobs with retries and local state snapshots.
+- Health checks, request IDs, service metrics, and smoke tests.
+- Separate Compose overlays for local devnet, production, backup, monitoring,
+  logging, and debug ports.
+
+These pieces add a little implementation surface area, but they keep expensive
+storage writes, long FFmpeg work, and public playback metadata recoverable.

--- a/docs/DISASTER_RECOVERY.md
+++ b/docs/DISASTER_RECOVERY.md
@@ -9,7 +9,9 @@ recovery focuses on the app-data directory:
 - `.env.production`: recreate from `.env.production.example` and restore real secrets from a secret manager.
 
 The backup sidecar and `scripts/backup-production.sh` capture SQLite and catalog
-state. See `docs/BACKUP_SIDECAR.md` for scheduled backups.
+state. See [Backup sidecar](BACKUP_SIDECAR.md) for scheduled backups and
+[Architecture](ARCHITECTURE.md) for how SQLite, Autonomi, and the local catalog
+state file divide recovery responsibilities.
 
 ## Restore To A New Host
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# Documentation
+
+Start with the root [README](../README.md) for the quick start, service list,
+environment variables, and API reference. The docs in this directory go deeper
+on operational and architectural topics.
+
+## Architecture
+
+- [Architecture](ARCHITECTURE.md) explains the service boundaries, durable job
+  flow, catalog state model, and reliability decisions.
+- [Runtime modes](RUNTIME_MODES.md) documents the Compose and standalone runtime
+  contracts.
+- [Runtime contract example](runtime-contract.example.json) shows the
+  machine-readable endpoint and path contract used by native hosts.
+
+## Operations
+
+- [Deployment](DEPLOYMENT.md) covers local, public-demo, and production Compose
+  modes.
+- [Observability](OBSERVABILITY.md) covers Prometheus, Grafana, Alertmanager,
+  Loki, and Promtail.
+- [Alertmanager setup](ALERTMANAGER_SETUP.md) shows how to replace the default
+  no-op alert receiver.
+- [Backup sidecar](BACKUP_SIDECAR.md) covers scheduled SQLite and catalog-state
+  backups.
+- [Disaster recovery](DISASTER_RECOVERY.md) covers recovery from backups and
+  network-hosted catalog documents.
+- [Troubleshooting](TROUBLESHOOTING.md) collects common local and production
+  failure modes.
+- [Performance tuning](PERFORMANCE_TUNING.md) covers upload, FFmpeg, Autonomi,
+  and stream-cache settings.
+- [Image publishing](IMAGE_PUBLISHING.md) covers GHCR image build and tag
+  workflows.

--- a/rust_admin/src/catalog/state_file.rs
+++ b/rust_admin/src/catalog/state_file.rs
@@ -1,3 +1,14 @@
+//! Local catalog bookmark and recovery state.
+//!
+//! The admin service intentionally writes catalog state to this JSON file even
+//! though SQLite stores the canonical admin metadata. The file is a lightweight
+//! bootstrap and recovery aid shared with the streaming service: it records the
+//! latest network-hosted catalog addresses plus decoded catalog snapshots, so a
+//! restarted stack can resume catalog reads before or without a database query.
+//! SQLite remains the source for mutable admin state and durable jobs, while
+//! Autonomi remains the durable playback source for ready manifests, segments,
+//! and published catalog documents.
+
 use std::{
     fs,
     path::{Path as FsPath, PathBuf},


### PR DESCRIPTION
## Summary
- Document why the JSON catalog state file is retained alongside SQLite.
- Add `docs/README.md` and `docs/ARCHITECTURE.md` as contributor-facing navigation and architecture notes.
- Link the new docs from the root README.

## Validation
- `cargo fmt --all --check`
- `cargo test -p rust_admin`
- Final stack: `make ci`