### PR TITLE
Extract frontend library and playback hooks

### DIFF
--- a/react_frontend/src/__tests__/playback.test.tsx
+++ b/react_frontend/src/__tests__/playback.test.tsx
@@ -519,6 +519,89 @@ test("resumes native HLS after a scrub near the beginning once a resolution chan
   expect(play).toHaveBeenCalled();
 });
 
+test("retries native HLS playback when a post-seek stall leaves playback paused", async () => {
+  Hls.isSupported.mockReturnValue(false);
+  vi.spyOn(HTMLMediaElement.prototype, "canPlayType").mockImplementation((type) => (
+    type === "application/vnd.apple.mpegurl" ? "maybe" : ""
+  ));
+  vi.spyOn(HTMLMediaElement.prototype, "load").mockImplementation(function load() {
+    this.currentTime = 0;
+  });
+  const publicVideo = {
+    created_at: "2026-04-27T12:00:00Z",
+    description: "Public description only",
+    id: "pub-native-stall-retry",
+    original_filename: "",
+    status: "published",
+    title: "Native stall retry stream",
+  };
+  setupGetRoutes({
+    publicVideos: [publicVideo],
+    details: {
+      "/api/videos/pub-native-stall-retry": {
+        ...publicVideo,
+        manifest_address: null,
+        variants: [
+          { id: "variant-720", resolution: "720p", segment_count: 20 },
+          { id: "variant-480", resolution: "480p", segment_count: 20 },
+        ],
+      },
+    },
+  });
+
+  await renderApp();
+  await waitFor(() => expect(text()).toContain("Native stall retry stream"));
+  await click(findButton("Native stall retry stream"));
+
+  const video = container.querySelector("video");
+  let currentTime = 15;
+  let paused = false;
+  Object.defineProperties(video, {
+    currentTime: {
+      configurable: true,
+      get: () => currentTime,
+      set: (value) => {
+        currentTime = value;
+      },
+    },
+    duration: { configurable: true, value: 20 },
+    ended: { configurable: true, value: false },
+    paused: {
+      configurable: true,
+      get: () => paused,
+    },
+    play: {
+      configurable: true,
+      value: vi.fn(() => {
+        paused = false;
+        return Promise.resolve();
+      }),
+    },
+    readyState: { configurable: true, value: 1 },
+  });
+
+  await click(container.querySelector(".quality-toggle"));
+  await click(findButton("480p"));
+  await act(async () => {
+    video.dispatchEvent(new Event("loadedmetadata"));
+    video.dispatchEvent(new Event("playing"));
+  });
+  const play = video.play as ReturnType<typeof vi.fn>;
+  play.mockClear();
+
+  vi.useFakeTimers();
+  await act(async () => {
+    currentTime = 6;
+    video.dispatchEvent(new Event("waiting"));
+    currentTime = 2;
+    paused = true;
+    vi.advanceTimersByTime(750);
+  });
+
+  expect(video.currentTime).toBe(6);
+  expect(play).toHaveBeenCalled();
+});
+
 test("closes the playback resolution menu when the pointer leaves it", async () => {
   const publicVideo = {
     created_at: "2026-04-27T12:00:00Z",

--- a/react_frontend/src/components/Library.tsx
+++ b/react_frontend/src/components/Library.tsx
@@ -1,19 +1,5 @@
-import { useCallback, useEffect, useState, type MouseEvent } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-
-import {
-  approveVideoUpload,
-  deleteVideoRecord,
-  getAdminCatalogs,
-  getVideoDetails,
-  listVideos,
-  publishAdminCatalogs,
-  requestErrorMessage,
-  updateVideoPublication,
-  updateVideoVisibility,
-} from "../api/client";
-import type { AdminCatalogs, VideoDetail, VideoSummary, VisibilityUpdate } from "../types";
-import { isActiveStatus, statusLabel } from "../utils/status";
+import { useVideoLibrary } from "../hooks/useVideoLibrary";
+import { statusLabel } from "../utils/status";
 import FinalQuotePanel from "./FinalQuotePanel";
 import VideoPlayer from "./VideoPlayer";
 
@@ -21,218 +7,30 @@ interface LibraryProps {
   admin?: boolean;
 }
 
-interface PlayingState {
-  resolution: string;
-  videoId: string;
-}
-
 export default function Library({ admin = false }: LibraryProps) {
-  const navigate = useNavigate();
-  const { videoId: routeVideoId } = useParams<{ videoId?: string }>();
-  const detailBasePath = admin ? "/manage" : "/library";
-  const [videos, setVideos] = useState<VideoSummary[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [playing, setPlaying] = useState<PlayingState | null>(null);
-  const [detail, setDetail] = useState<VideoDetail | null>(null);
-  const [approving, setApproving] = useState<string | null>(null);
-  const [publishing, setPublishing] = useState<string | null>(null);
-  const [catalogs, setCatalogs] = useState<AdminCatalogs | null>(null);
-  const [catalogPublishing, setCatalogPublishing] = useState(false);
-  const [catalogCopied, setCatalogCopied] = useState("");
-  const [loadError, setLoadError] = useState("");
-  const [detailError, setDetailError] = useState("");
-  const [actionError, setActionError] = useState("");
-  const [catalogError, setCatalogError] = useState("");
-  const activeDetailId = detail?.id;
-  const activeDetailStatus = detail?.status;
-
-  const load = useCallback(async () => {
-    try {
-      const data = await listVideos({ admin });
-      setVideos(data);
-      setLoadError("");
-    } catch (err) {
-      setLoadError(requestErrorMessage(err, "Could not load the video catalog."));
-    } finally {
-      setLoading(false);
-    }
-  }, [admin]);
-
-  const loadDetail = useCallback(async (videoId: string) => {
-    setDetailError("");
-    setActionError("");
-    try {
-      const data = await getVideoDetails({ admin, videoId });
-      setDetail(data);
-    } catch (err) {
-      setDetailError(requestErrorMessage(err, "Could not load video details."));
-    }
-  }, [admin]);
-
-  const loadCatalogs = useCallback(async () => {
-    if (!admin) return;
-    try {
-      const data = await getAdminCatalogs();
-      setCatalogs(data);
-      setCatalogError("");
-    } catch (err) {
-      setCatalogError(requestErrorMessage(err, "Could not load catalog addresses."));
-    }
-  }, [admin]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  useEffect(() => {
-    loadCatalogs();
-  }, [loadCatalogs]);
-
-  useEffect(() => {
-    if (!routeVideoId) {
-      setDetail(null);
-      return;
-    }
-
-    let active = true;
-    setDetailError("");
-    setActionError("");
-    getVideoDetails({ admin, videoId: routeVideoId })
-      .then((data) => {
-        if (active) setDetail(data);
-      })
-      .catch((err) => {
-        if (active) {
-          setDetail(null);
-          setDetailError(requestErrorMessage(err, "Could not load video details."));
-        }
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [admin, routeVideoId]);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      if (videos.some((video) => isActiveStatus(video.status))) {
-        load();
-      }
-    }, 5000);
-    return () => clearInterval(interval);
-  }, [videos, load]);
-
-  useEffect(() => {
-    if (!activeDetailId || !isActiveStatus(activeDetailStatus)) return undefined;
-    const interval = setInterval(async () => {
-      try {
-        const data = await getVideoDetails({ admin, videoId: activeDetailId });
-        setDetail(data);
-        setDetailError("");
-      } catch (err) {
-        setDetailError(requestErrorMessage(err, "Could not refresh video details."));
-      }
-    }, 5000);
-    return () => clearInterval(interval);
-  }, [activeDetailId, activeDetailStatus, admin]);
-
-  const openDetail = async (videoId: string) => {
-    if (routeVideoId === videoId && detail?.id === videoId) {
-      navigate(detailBasePath);
-      return;
-    }
-    if (routeVideoId === videoId) {
-      await loadDetail(videoId);
-      return;
-    }
-    navigate(`${detailBasePath}/${encodeURIComponent(videoId)}`);
-  };
-
-  const deleteVideo = async (videoId: string, event: MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
-    if (!window.confirm("Delete this video record and remove it from the network catalog?")) return;
-    setActionError("");
-    try {
-      await deleteVideoRecord(videoId);
-      setVideos((prev) => prev.filter((video) => video.id !== videoId));
-      await loadCatalogs();
-      if (detail?.id === videoId) {
-        setDetail(null);
-        navigate(detailBasePath, { replace: true });
-      }
-      if (playing?.videoId === videoId) setPlaying(null);
-    } catch (err) {
-      setActionError(requestErrorMessage(err, "Delete failed."));
-    }
-  };
-
-  const approveVideo = async (videoId: string) => {
-    setApproving(videoId);
-    setActionError("");
-    try {
-      const data = await approveVideoUpload(videoId);
-      setDetail(data);
-      await load();
-      await loadCatalogs();
-    } catch (err) {
-      const message = requestErrorMessage(err, "Approval failed.");
-      setActionError(message);
-      window.alert(message);
-    } finally {
-      setApproving(null);
-    }
-  };
-
-  const updateVisibility = async (videoId: string, next: VisibilityUpdate) => {
-    setActionError("");
-    try {
-      const data = await updateVideoVisibility(videoId, next);
-      setDetail(data);
-      setVideos((prev) => prev.map((video) => (video.id === videoId ? { ...video, ...data } : video)));
-      await loadCatalogs();
-    } catch (err) {
-      setActionError(requestErrorMessage(err, "Visibility update failed."));
-    }
-  };
-
-  const updatePublication = async (videoId: string, isPublic: boolean) => {
-    setPublishing(videoId);
-    setActionError("");
-    try {
-      const data = await updateVideoPublication(videoId, isPublic);
-      setDetail(data);
-      setVideos((prev) => prev.map((video) => (video.id === videoId ? { ...video, ...data } : video)));
-      await loadCatalogs();
-    } catch (err) {
-      setActionError(requestErrorMessage(err, isPublic ? "Publish failed." : "Unpublish failed."));
-    } finally {
-      setPublishing(null);
-    }
-  };
-
-  const republishCatalogs = async () => {
-    setCatalogPublishing(true);
-    setCatalogError("");
-    setCatalogCopied("");
-    try {
-      const data = await publishAdminCatalogs();
-      setCatalogs(data);
-    } catch (err) {
-      setCatalogError(requestErrorMessage(err, "Catalog publish failed."));
-    } finally {
-      setCatalogPublishing(false);
-    }
-  };
-
-  const copyAddress = async (label: string, address?: string | null) => {
-    if (!address) return;
-    try {
-      await navigator.clipboard.writeText(address);
-      setCatalogCopied(label);
-    } catch {
-      setCatalogError("Could not copy the catalog address.");
-    }
-  };
+  const {
+    actionError,
+    approveVideo,
+    approving,
+    catalogCopied,
+    catalogError,
+    catalogPublishing,
+    catalogs,
+    copyAddress,
+    deleteVideo,
+    detail,
+    detailError,
+    loadError,
+    loading,
+    openDetail,
+    playing,
+    publishing,
+    republishCatalogs,
+    setPlaying,
+    updatePublication,
+    updateVisibility,
+    videos,
+  } = useVideoLibrary(admin);
 
   if (loading) {
     return (

--- a/react_frontend/src/components/VideoPlayer.tsx
+++ b/react_frontend/src/components/VideoPlayer.tsx
@@ -1,29 +1,10 @@
 import { useCallback, useEffect, useRef, useState, type FocusEvent } from "react";
-import type Hls from "hls.js";
 
-import { PLAYER_CONTROLS_IDLE_MS, RESUME_DURATION_TOLERANCE_SECONDS } from "../constants";
+import { PLAYER_CONTROLS_IDLE_MS } from "../constants";
+import { useHlsPlayback } from "../hooks/useHlsPlayback";
 import { STREAM_BASE_URL } from "../runtimeConfig";
 import type { VideoVariant } from "../types";
 import { variantDisplayLabel } from "../utils/resolutions";
-
-const HLS_RETRY_CONFIG = {
-  fragLoadingMaxRetry: 4,
-  fragLoadingMaxRetryTimeout: 8_000,
-  fragLoadingRetryDelay: 500,
-  levelLoadingMaxRetry: 4,
-  levelLoadingMaxRetryTimeout: 8_000,
-  levelLoadingRetryDelay: 500,
-  manifestLoadingMaxRetry: 4,
-  manifestLoadingMaxRetryTimeout: 8_000,
-  manifestLoadingRetryDelay: 500,
-};
-const HLS_FATAL_RECOVERY_ATTEMPTS = 1;
-const MEDIA_HAVE_FUTURE_DATA = 3;
-
-interface PlaybackState {
-  currentTime: number;
-  shouldResume: boolean;
-}
 
 interface VideoPlayerProps {
   manifestAddress?: string | null;
@@ -41,18 +22,23 @@ export default function VideoPlayer({
   onResolutionChange,
 }: VideoPlayerProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  const hlsRef = useRef<Hls | null>(null);
   const controlsIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const playbackStateRef = useRef<PlaybackState>({ currentTime: 0, shouldResume: false });
-  const playbackIntentRef = useRef(false);
   const [qualityOpen, setQualityOpen] = useState(false);
   const [controlsActive, setControlsActive] = useState(true);
-  const [playbackError, setPlaybackError] = useState("");
   const streamBase = manifestAddress
     ? `${STREAM_BASE_URL}/manifest/${manifestAddress}`
     : `${STREAM_BASE_URL}/${videoId}`;
   const src = `${streamBase}/${resolution}/playlist.m3u8`;
   const selectedLabel = variantDisplayLabel(resolution);
+  const {
+    capturePlaybackState,
+    clearPlaybackIntent,
+    markPlaybackIntent,
+    playbackError,
+  } = useHlsPlayback({
+    src,
+    videoRef,
+  });
 
   const clearControlsIdleTimer = useCallback(() => {
     if (controlsIdleTimerRef.current) {
@@ -84,19 +70,6 @@ export default function VideoPlayer({
     scheduleControlsIdleHide();
   }, [scheduleControlsIdleHide]);
 
-  const capturePlaybackStateFromVideo = useCallback((video: HTMLVideoElement) => {
-    playbackStateRef.current = {
-      currentTime: Number.isFinite(video.currentTime) ? video.currentTime : 0,
-      shouldResume: playbackIntentRef.current || (!video.paused && !video.ended),
-    };
-  }, []);
-
-  const capturePlaybackState = useCallback(() => {
-    const video = videoRef.current;
-    if (!video) return;
-    capturePlaybackStateFromVideo(video);
-  }, [capturePlaybackStateFromVideo]);
-
   const handleResolutionChange = useCallback((nextResolution: string) => {
     capturePlaybackState();
     onResolutionChange(nextResolution);
@@ -106,258 +79,18 @@ export default function VideoPlayer({
     const video = videoRef.current;
     if (!video) return undefined;
 
-    setPlaybackError("");
-    let active = true;
-    let cleanupPlayback = () => {};
-    const { currentTime: resumeAt, shouldResume } = playbackStateRef.current;
-    let pendingResumeAt = resumeAt;
-    let restorePending = resumeAt > 0;
-    let hlsManifestParsed = false;
-    let resumedAfterRestore = false;
-    let nativeSeekRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
-    let nativeSeekResumeAt = 0;
-    let nativeSeekShouldResume = false;
-    const readCurrentTime = () => (
-      Number.isFinite(video.currentTime) ? video.currentTime : 0
-    );
-    const clearNativeSeekRecoveryTimer = () => {
-      if (nativeSeekRecoveryTimer) {
-        clearTimeout(nativeSeekRecoveryTimer);
-        nativeSeekRecoveryTimer = null;
-      }
-    };
-    const wantsPlayback = () => (
-      playbackIntentRef.current || (!video.paused && !video.ended)
-    );
-    const requestPlayback = () => {
-      playbackIntentRef.current = true;
-      video.play().catch(() => {});
-    };
-    const scheduleNativeSeekRecovery = () => {
-      clearNativeSeekRecoveryTimer();
-      if (!nativeSeekShouldResume) return;
-
-      nativeSeekRecoveryTimer = setTimeout(() => {
-        nativeSeekRecoveryTimer = null;
-        if (!active || !nativeSeekShouldResume || video.ended) return;
-
-        if (video.paused || video.readyState < MEDIA_HAVE_FUTURE_DATA) {
-          try {
-            if (Math.abs(readCurrentTime() - nativeSeekResumeAt) > RESUME_DURATION_TOLERANCE_SECONDS) {
-              video.currentTime = nativeSeekResumeAt;
-            }
-          } catch {
-            // Safari can reject seeks while native HLS is swapping internal buffers.
-          }
-          requestPlayback();
-          scheduleNativeSeekRecovery();
-        }
-      }, 750);
-    };
-    const syncPendingSeek = () => {
-      if (!restorePending) return;
-      pendingResumeAt = readCurrentTime();
-      playbackStateRef.current = { currentTime: pendingResumeAt, shouldResume };
-
-      const hls = hlsRef.current;
-      if (hls && hlsManifestParsed) {
-        hls.startLoad(pendingResumeAt > 0 ? pendingResumeAt : 0);
-      }
-    };
-    const finishRestore = () => {
-      restorePending = false;
-      video.removeEventListener("canplay", finishRestore);
-      video.removeEventListener("playing", finishRestore);
-    };
-    const resumePlayback = () => {
-      if (shouldResume && !resumedAfterRestore) {
-        resumedAfterRestore = true;
-        requestPlayback();
-      }
-    };
-    const removeNativeRestoreListeners = () => {
-      video.removeEventListener("canplay", restoreNativePlayback);
-      video.removeEventListener("durationchange", restoreNativePlayback);
-      video.removeEventListener("loadeddata", restoreNativePlayback);
-      video.removeEventListener("loadedmetadata", restoreNativePlayback);
-      video.removeEventListener("seeking", syncPendingSeek);
-    };
-    const restoreNativePlayback = () => {
-      if (pendingResumeAt > 0) {
-        const duration = video.duration;
-        if (
-          Number.isFinite(duration) &&
-          duration <= pendingResumeAt + RESUME_DURATION_TOLERANCE_SECONDS
-        ) {
-          return;
-        }
-
-        try {
-          video.currentTime = pendingResumeAt;
-        } catch {
-          return;
-        }
-      }
-
-      finishRestore();
-      resumePlayback();
-      removeNativeRestoreListeners();
-    };
-
-    const attachNativePlayback = () => {
-      const onNativePlaybackError = () => {
-        setPlaybackError("Playback failed because the video segments could not be loaded.");
-      };
-      const rememberNativeSeekIntent = () => {
-        nativeSeekResumeAt = readCurrentTime();
-        nativeSeekShouldResume = restorePending
-          ? wantsPlayback() || shouldResume
-          : wantsPlayback();
-        if (nativeSeekShouldResume) scheduleNativeSeekRecovery();
-      };
-      const resumeAfterNativeSeek = () => {
-        nativeSeekResumeAt = readCurrentTime();
-        if (!nativeSeekShouldResume) return;
-        requestPlayback();
-        scheduleNativeSeekRecovery();
-      };
-      const finishNativeSeekRecovery = () => {
-        nativeSeekShouldResume = false;
-        clearNativeSeekRecoveryTimer();
-      };
-      const recoverNativeSeekStall = () => {
-        if (!nativeSeekShouldResume && !wantsPlayback()) return;
-        nativeSeekResumeAt = readCurrentTime();
-        nativeSeekShouldResume = true;
-        scheduleNativeSeekRecovery();
-      };
-      const cancelNativeSeekRecovery = () => {
-        if (video.seeking) return;
-        nativeSeekShouldResume = false;
-        clearNativeSeekRecoveryTimer();
-      };
-      video.addEventListener("canplay", restoreNativePlayback);
-      video.addEventListener("durationchange", restoreNativePlayback);
-      video.addEventListener("loadeddata", restoreNativePlayback);
-      video.addEventListener("loadedmetadata", restoreNativePlayback);
-      video.addEventListener("seeking", syncPendingSeek);
-      video.addEventListener("seeking", rememberNativeSeekIntent);
-      video.addEventListener("seeked", resumeAfterNativeSeek);
-      video.addEventListener("canplay", resumeAfterNativeSeek);
-      video.addEventListener("playing", finishNativeSeekRecovery);
-      video.addEventListener("pause", cancelNativeSeekRecovery);
-      video.addEventListener("stalled", recoverNativeSeekStall);
-      video.addEventListener("waiting", recoverNativeSeekStall);
-      video.addEventListener("error", onNativePlaybackError, { once: true });
-      video.src = src;
-      video.load();
-      cleanupPlayback = () => {
-        clearNativeSeekRecoveryTimer();
-        removeNativeRestoreListeners();
-        video.removeEventListener("seeking", rememberNativeSeekIntent);
-        video.removeEventListener("seeked", resumeAfterNativeSeek);
-        video.removeEventListener("canplay", resumeAfterNativeSeek);
-        video.removeEventListener("playing", finishNativeSeekRecovery);
-        video.removeEventListener("pause", cancelNativeSeekRecovery);
-        video.removeEventListener("stalled", recoverNativeSeekStall);
-        video.removeEventListener("waiting", recoverNativeSeekStall);
-        video.removeEventListener("error", onNativePlaybackError);
-        video.removeAttribute("src");
-        video.load();
-      };
-    };
-
-    import("hls.js").then(({ default: Hls }) => {
-      if (!active) return;
-      if (Hls.isSupported()) {
-        let mediaRecoveryAttempts = 0;
-        let networkRecoveryAttempts = 0;
-        const hls = new Hls({
-          enableWorker: true,
-          ...HLS_RETRY_CONFIG,
-          autoStartLoad: resumeAt > 0 ? false : true,
-          lowLatencyMode: false,
-          startPosition: resumeAt > 0 ? resumeAt : -1,
-        });
-        hlsRef.current = hls;
-        hls.loadSource(src);
-        hls.attachMedia(video);
-        video.addEventListener("canplay", finishRestore);
-        video.addEventListener("playing", finishRestore);
-        video.addEventListener("seeking", syncPendingSeek);
-        hls.on(Hls.Events.MANIFEST_PARSED, () => {
-          hlsManifestParsed = true;
-          if (restorePending) {
-            hls.startLoad(pendingResumeAt > 0 ? pendingResumeAt : 0);
-          }
-          resumePlayback();
-        });
-        hls.on(Hls.Events.ERROR, (_event, data) => {
-          if (data?.fatal) {
-            if (
-              data.type === Hls.ErrorTypes.NETWORK_ERROR
-              && networkRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
-            ) {
-              networkRecoveryAttempts += 1;
-              hls.startLoad();
-              return;
-            }
-
-            if (
-              data.type === Hls.ErrorTypes.MEDIA_ERROR
-              && mediaRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
-            ) {
-              mediaRecoveryAttempts += 1;
-              hls.recoverMediaError();
-              return;
-            }
-
-            setPlaybackError("Playback failed because the video segments could not be loaded.");
-          }
-        });
-        cleanupPlayback = () => {
-          video.removeEventListener("canplay", finishRestore);
-          video.removeEventListener("playing", finishRestore);
-          video.removeEventListener("seeking", syncPendingSeek);
-          hls.destroy();
-          hlsRef.current = null;
-        };
-        return;
-      }
-
-      if (video.canPlayType("application/vnd.apple.mpegurl")) {
-        attachNativePlayback();
-      }
-    }).catch(() => {
-      if (active && video.canPlayType("application/vnd.apple.mpegurl")) {
-        attachNativePlayback();
-      }
-    });
-
-    return () => {
-      active = false;
-      capturePlaybackStateFromVideo(video);
-      cleanupPlayback();
-      hlsRef.current = null;
-    };
-  }, [capturePlaybackStateFromVideo, src]);
-
-  useEffect(() => {
-    const video = videoRef.current;
-    if (!video) return undefined;
-
     const handlePlay = () => {
-      playbackIntentRef.current = true;
+      markPlaybackIntent();
       setControlsActive(true);
       scheduleControlsIdleHide();
     };
     const handlePause = () => {
-      if (!video.seeking) playbackIntentRef.current = false;
+      if (!video.seeking) clearPlaybackIntent();
       clearControlsIdleTimer();
       setControlsActive(true);
     };
     const handleEnded = () => {
-      playbackIntentRef.current = false;
+      clearPlaybackIntent();
       handlePause();
     };
 
@@ -369,7 +102,12 @@ export default function VideoPlayer({
       video.removeEventListener("pause", handlePause);
       video.removeEventListener("ended", handleEnded);
     };
-  }, [clearControlsIdleTimer, scheduleControlsIdleHide]);
+  }, [
+    clearControlsIdleTimer,
+    clearPlaybackIntent,
+    markPlaybackIntent,
+    scheduleControlsIdleHide,
+  ]);
 
   useEffect(() => clearControlsIdleTimer, [clearControlsIdleTimer]);
 

--- a/react_frontend/src/hooks/useAdminCatalogs.ts
+++ b/react_frontend/src/hooks/useAdminCatalogs.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  getAdminCatalogs,
+  publishAdminCatalogs,
+  requestErrorMessage,
+} from "../api/client";
+import type { AdminCatalogs } from "../types";
+
+export function useAdminCatalogs(admin: boolean) {
+  const [catalogs, setCatalogs] = useState<AdminCatalogs | null>(null);
+  const [catalogPublishing, setCatalogPublishing] = useState(false);
+  const [catalogCopied, setCatalogCopied] = useState("");
+  const [catalogError, setCatalogError] = useState("");
+
+  const loadCatalogs = useCallback(async () => {
+    if (!admin) return;
+    try {
+      const data = await getAdminCatalogs();
+      setCatalogs(data);
+      setCatalogError("");
+    } catch (err) {
+      setCatalogError(requestErrorMessage(err, "Could not load catalog addresses."));
+    }
+  }, [admin]);
+
+  useEffect(() => {
+    void loadCatalogs();
+  }, [loadCatalogs]);
+
+  const republishCatalogs = useCallback(async () => {
+    setCatalogPublishing(true);
+    setCatalogError("");
+    setCatalogCopied("");
+    try {
+      const data = await publishAdminCatalogs();
+      setCatalogs(data);
+    } catch (err) {
+      setCatalogError(requestErrorMessage(err, "Catalog publish failed."));
+    } finally {
+      setCatalogPublishing(false);
+    }
+  }, []);
+
+  const copyAddress = useCallback(async (label: string, address?: string | null) => {
+    if (!address) return;
+    try {
+      await navigator.clipboard.writeText(address);
+      setCatalogCopied(label);
+    } catch {
+      setCatalogError("Could not copy the catalog address.");
+    }
+  }, []);
+
+  return {
+    catalogCopied,
+    catalogError,
+    catalogPublishing,
+    catalogs,
+    copyAddress,
+    loadCatalogs,
+    republishCatalogs,
+  };
+}

--- a/react_frontend/src/hooks/useHlsPlayback.ts
+++ b/react_frontend/src/hooks/useHlsPlayback.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import type Hls from "hls.js";
+
+import { useNativeHlsPlayback, type PlaybackState } from "./useNativeHlsPlayback";
+
+const HLS_RETRY_CONFIG = {
+  fragLoadingMaxRetry: 4,
+  fragLoadingMaxRetryTimeout: 8_000,
+  fragLoadingRetryDelay: 500,
+  levelLoadingMaxRetry: 4,
+  levelLoadingMaxRetryTimeout: 8_000,
+  levelLoadingRetryDelay: 500,
+  manifestLoadingMaxRetry: 4,
+  manifestLoadingMaxRetryTimeout: 8_000,
+  manifestLoadingRetryDelay: 500,
+};
+const HLS_FATAL_RECOVERY_ATTEMPTS = 1;
+
+interface UseHlsPlaybackOptions {
+  src: string;
+  videoRef: RefObject<HTMLVideoElement>;
+}
+
+export function useHlsPlayback({ src, videoRef }: UseHlsPlaybackOptions) {
+  const hlsRef = useRef<Hls | null>(null);
+  const playbackStateRef = useRef<PlaybackState>({ currentTime: 0, shouldResume: false });
+  const playbackIntentRef = useRef(false);
+  const [playbackError, setPlaybackError] = useState("");
+  const attachNativePlayback = useNativeHlsPlayback({
+    playbackIntentRef,
+    playbackStateRef,
+    setPlaybackError,
+  });
+
+  const capturePlaybackStateFromVideo = useCallback((video: HTMLVideoElement) => {
+    playbackStateRef.current = {
+      currentTime: Number.isFinite(video.currentTime) ? video.currentTime : 0,
+      shouldResume: playbackIntentRef.current || (!video.paused && !video.ended),
+    };
+  }, []);
+
+  const capturePlaybackState = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    capturePlaybackStateFromVideo(video);
+  }, [capturePlaybackStateFromVideo, videoRef]);
+
+  const markPlaybackIntent = useCallback(() => {
+    playbackIntentRef.current = true;
+  }, []);
+
+  const clearPlaybackIntent = useCallback(() => {
+    playbackIntentRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return undefined;
+
+    setPlaybackError("");
+    let active = true;
+    let cleanupPlayback = () => {};
+    const { currentTime: resumeAt, shouldResume } = playbackStateRef.current;
+    let pendingResumeAt = resumeAt;
+    let restorePending = resumeAt > 0;
+    let hlsManifestParsed = false;
+    let resumedAfterRestore = false;
+    const readCurrentTime = () => (
+      Number.isFinite(video.currentTime) ? video.currentTime : 0
+    );
+    const requestPlayback = () => {
+      playbackIntentRef.current = true;
+      video.play().catch(() => {});
+    };
+    const syncPendingSeek = () => {
+      if (!restorePending) return;
+      pendingResumeAt = readCurrentTime();
+      playbackStateRef.current = { currentTime: pendingResumeAt, shouldResume };
+
+      const hls = hlsRef.current;
+      if (hls && hlsManifestParsed) {
+        hls.startLoad(pendingResumeAt > 0 ? pendingResumeAt : 0);
+      }
+    };
+    const finishRestore = () => {
+      restorePending = false;
+      video.removeEventListener("canplay", finishRestore);
+      video.removeEventListener("playing", finishRestore);
+    };
+    const resumePlayback = () => {
+      if (shouldResume && !resumedAfterRestore) {
+        resumedAfterRestore = true;
+        requestPlayback();
+      }
+    };
+    const attachHlsPlayback = (HlsConstructor: typeof Hls) => {
+      let mediaRecoveryAttempts = 0;
+      let networkRecoveryAttempts = 0;
+      const hls = new HlsConstructor({
+        enableWorker: true,
+        ...HLS_RETRY_CONFIG,
+        autoStartLoad: resumeAt > 0 ? false : true,
+        lowLatencyMode: false,
+        startPosition: resumeAt > 0 ? resumeAt : -1,
+      });
+      hlsRef.current = hls;
+      hls.loadSource(src);
+      hls.attachMedia(video);
+      video.addEventListener("canplay", finishRestore);
+      video.addEventListener("playing", finishRestore);
+      video.addEventListener("seeking", syncPendingSeek);
+      hls.on(HlsConstructor.Events.MANIFEST_PARSED, () => {
+        hlsManifestParsed = true;
+        if (restorePending) {
+          hls.startLoad(pendingResumeAt > 0 ? pendingResumeAt : 0);
+        }
+        resumePlayback();
+      });
+      hls.on(HlsConstructor.Events.ERROR, (_event, data) => {
+        if (data?.fatal) {
+          if (
+            data.type === HlsConstructor.ErrorTypes.NETWORK_ERROR
+            && networkRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
+          ) {
+            networkRecoveryAttempts += 1;
+            hls.startLoad();
+            return;
+          }
+
+          if (
+            data.type === HlsConstructor.ErrorTypes.MEDIA_ERROR
+            && mediaRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
+          ) {
+            mediaRecoveryAttempts += 1;
+            hls.recoverMediaError();
+            return;
+          }
+
+          setPlaybackError("Playback failed because the video segments could not be loaded.");
+        }
+      });
+      cleanupPlayback = () => {
+        video.removeEventListener("canplay", finishRestore);
+        video.removeEventListener("playing", finishRestore);
+        video.removeEventListener("seeking", syncPendingSeek);
+        hls.destroy();
+        hlsRef.current = null;
+      };
+    };
+    const attachNativeFallback = () => {
+      if (video.canPlayType("application/vnd.apple.mpegurl")) {
+        cleanupPlayback = attachNativePlayback(video, src, () => active);
+      }
+    };
+
+    import("hls.js").then(({ default: HlsConstructor }) => {
+      if (!active) return;
+      if (HlsConstructor.isSupported()) {
+        attachHlsPlayback(HlsConstructor);
+        return;
+      }
+
+      attachNativeFallback();
+    }).catch(() => {
+      if (active) attachNativeFallback();
+    });
+
+    return () => {
+      active = false;
+      capturePlaybackStateFromVideo(video);
+      cleanupPlayback();
+      hlsRef.current = null;
+    };
+  }, [attachNativePlayback, capturePlaybackStateFromVideo, src, videoRef]);
+
+  return {
+    capturePlaybackState,
+    clearPlaybackIntent,
+    markPlaybackIntent,
+    playbackError,
+  };
+}

--- a/react_frontend/src/hooks/useNativeHlsPlayback.ts
+++ b/react_frontend/src/hooks/useNativeHlsPlayback.ts
@@ -1,0 +1,178 @@
+import { useCallback, type MutableRefObject } from "react";
+
+import { RESUME_DURATION_TOLERANCE_SECONDS } from "../constants";
+
+const MEDIA_HAVE_FUTURE_DATA = 3;
+
+export interface PlaybackState {
+  currentTime: number;
+  shouldResume: boolean;
+}
+
+interface UseNativeHlsPlaybackOptions {
+  playbackIntentRef: MutableRefObject<boolean>;
+  playbackStateRef: MutableRefObject<PlaybackState>;
+  setPlaybackError: (message: string) => void;
+}
+
+export function useNativeHlsPlayback({
+  playbackIntentRef,
+  playbackStateRef,
+  setPlaybackError,
+}: UseNativeHlsPlaybackOptions) {
+  return useCallback((video: HTMLVideoElement, src: string, isActive: () => boolean) => {
+    const { currentTime: resumeAt, shouldResume } = playbackStateRef.current;
+    let pendingResumeAt = resumeAt;
+    let restorePending = resumeAt > 0;
+    let resumedAfterRestore = false;
+    let nativeSeekRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+    let nativeSeekResumeAt = 0;
+    let nativeSeekShouldResume = false;
+    const readCurrentTime = () => (
+      Number.isFinite(video.currentTime) ? video.currentTime : 0
+    );
+    const clearNativeSeekRecoveryTimer = () => {
+      if (nativeSeekRecoveryTimer) {
+        clearTimeout(nativeSeekRecoveryTimer);
+        nativeSeekRecoveryTimer = null;
+      }
+    };
+    const wantsPlayback = () => (
+      playbackIntentRef.current || (!video.paused && !video.ended)
+    );
+    const requestPlayback = () => {
+      playbackIntentRef.current = true;
+      video.play().catch(() => {});
+    };
+    const scheduleNativeSeekRecovery = () => {
+      clearNativeSeekRecoveryTimer();
+      if (!nativeSeekShouldResume) return;
+
+      nativeSeekRecoveryTimer = setTimeout(() => {
+        nativeSeekRecoveryTimer = null;
+        if (!isActive() || !nativeSeekShouldResume || video.ended) return;
+
+        if (video.paused || video.readyState < MEDIA_HAVE_FUTURE_DATA) {
+          try {
+            if (
+              Math.abs(readCurrentTime() - nativeSeekResumeAt)
+              > RESUME_DURATION_TOLERANCE_SECONDS
+            ) {
+              video.currentTime = nativeSeekResumeAt;
+            }
+          } catch {
+            // Safari can reject seeks while native HLS swaps internal buffers.
+          }
+          requestPlayback();
+          scheduleNativeSeekRecovery();
+        }
+      }, 750);
+    };
+    const syncPendingSeek = () => {
+      if (!restorePending) return;
+      pendingResumeAt = readCurrentTime();
+      playbackStateRef.current = { currentTime: pendingResumeAt, shouldResume };
+    };
+    const finishRestore = () => {
+      restorePending = false;
+      video.removeEventListener("canplay", finishRestore);
+      video.removeEventListener("playing", finishRestore);
+    };
+    const resumePlayback = () => {
+      if (shouldResume && !resumedAfterRestore) {
+        resumedAfterRestore = true;
+        requestPlayback();
+      }
+    };
+    const removeNativeRestoreListeners = () => {
+      video.removeEventListener("canplay", restoreNativePlayback);
+      video.removeEventListener("durationchange", restoreNativePlayback);
+      video.removeEventListener("loadeddata", restoreNativePlayback);
+      video.removeEventListener("loadedmetadata", restoreNativePlayback);
+      video.removeEventListener("seeking", syncPendingSeek);
+    };
+    const restoreNativePlayback = () => {
+      if (pendingResumeAt > 0) {
+        const duration = video.duration;
+        if (
+          Number.isFinite(duration)
+          && duration <= pendingResumeAt + RESUME_DURATION_TOLERANCE_SECONDS
+        ) {
+          return;
+        }
+
+        try {
+          video.currentTime = pendingResumeAt;
+        } catch {
+          return;
+        }
+      }
+
+      finishRestore();
+      resumePlayback();
+      removeNativeRestoreListeners();
+    };
+    const onNativePlaybackError = () => {
+      setPlaybackError("Playback failed because the video segments could not be loaded.");
+    };
+    const rememberNativeSeekIntent = () => {
+      nativeSeekResumeAt = readCurrentTime();
+      nativeSeekShouldResume = restorePending
+        ? wantsPlayback() || shouldResume
+        : wantsPlayback();
+      if (nativeSeekShouldResume) scheduleNativeSeekRecovery();
+    };
+    const resumeAfterNativeSeek = () => {
+      nativeSeekResumeAt = readCurrentTime();
+      if (!nativeSeekShouldResume) return;
+      requestPlayback();
+      scheduleNativeSeekRecovery();
+    };
+    const finishNativeSeekRecovery = () => {
+      nativeSeekShouldResume = false;
+      clearNativeSeekRecoveryTimer();
+    };
+    const recoverNativeSeekStall = () => {
+      if (!nativeSeekShouldResume && !wantsPlayback()) return;
+      nativeSeekResumeAt = readCurrentTime();
+      nativeSeekShouldResume = true;
+      scheduleNativeSeekRecovery();
+    };
+    const cancelNativeSeekRecovery = () => {
+      if (video.seeking) return;
+      nativeSeekShouldResume = false;
+      clearNativeSeekRecoveryTimer();
+    };
+
+    video.addEventListener("canplay", restoreNativePlayback);
+    video.addEventListener("durationchange", restoreNativePlayback);
+    video.addEventListener("loadeddata", restoreNativePlayback);
+    video.addEventListener("loadedmetadata", restoreNativePlayback);
+    video.addEventListener("seeking", syncPendingSeek);
+    video.addEventListener("seeking", rememberNativeSeekIntent);
+    video.addEventListener("seeked", resumeAfterNativeSeek);
+    video.addEventListener("canplay", resumeAfterNativeSeek);
+    video.addEventListener("playing", finishNativeSeekRecovery);
+    video.addEventListener("pause", cancelNativeSeekRecovery);
+    video.addEventListener("stalled", recoverNativeSeekStall);
+    video.addEventListener("waiting", recoverNativeSeekStall);
+    video.addEventListener("error", onNativePlaybackError, { once: true });
+    video.src = src;
+    video.load();
+
+    return () => {
+      clearNativeSeekRecoveryTimer();
+      removeNativeRestoreListeners();
+      video.removeEventListener("seeking", rememberNativeSeekIntent);
+      video.removeEventListener("seeked", resumeAfterNativeSeek);
+      video.removeEventListener("canplay", resumeAfterNativeSeek);
+      video.removeEventListener("playing", finishNativeSeekRecovery);
+      video.removeEventListener("pause", cancelNativeSeekRecovery);
+      video.removeEventListener("stalled", recoverNativeSeekStall);
+      video.removeEventListener("waiting", recoverNativeSeekStall);
+      video.removeEventListener("error", onNativePlaybackError);
+      video.removeAttribute("src");
+      video.load();
+    };
+  }, [playbackIntentRef, playbackStateRef, setPlaybackError]);
+}

--- a/react_frontend/src/hooks/useVideoDetailPolling.ts
+++ b/react_frontend/src/hooks/useVideoDetailPolling.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { getVideoDetails, requestErrorMessage } from "../api/client";
+import type { VideoDetail } from "../types";
+import { isActiveStatus } from "../utils/status";
+
+interface UseVideoDetailPollingOptions {
+  admin: boolean;
+  routeVideoId?: string;
+}
+
+export function useVideoDetailPolling({
+  admin,
+  routeVideoId,
+}: UseVideoDetailPollingOptions) {
+  const [detail, setDetail] = useState<VideoDetail | null>(null);
+  const [detailError, setDetailError] = useState("");
+  const [actionError, setActionError] = useState("");
+  const activeDetailId = detail?.id;
+  const activeDetailStatus = detail?.status;
+
+  const loadDetail = useCallback(async (videoId: string) => {
+    setDetailError("");
+    setActionError("");
+    try {
+      const data = await getVideoDetails({ admin, videoId });
+      setDetail(data);
+    } catch (err) {
+      setDetailError(requestErrorMessage(err, "Could not load video details."));
+    }
+  }, [admin]);
+
+  const clearActionError = useCallback(() => {
+    setActionError("");
+  }, []);
+
+  const showActionError = useCallback((message: string) => {
+    setActionError(message);
+  }, []);
+
+  const replaceDetail = useCallback((nextDetail: VideoDetail) => {
+    setDetail(nextDetail);
+  }, []);
+
+  const clearDetail = useCallback(() => {
+    setDetail(null);
+  }, []);
+
+  useEffect(() => {
+    if (!routeVideoId) {
+      setDetail(null);
+      return;
+    }
+
+    let active = true;
+    setDetailError("");
+    setActionError("");
+    getVideoDetails({ admin, videoId: routeVideoId })
+      .then((data) => {
+        if (active) setDetail(data);
+      })
+      .catch((err) => {
+        if (active) {
+          setDetail(null);
+          setDetailError(requestErrorMessage(err, "Could not load video details."));
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [admin, routeVideoId]);
+
+  useEffect(() => {
+    if (!activeDetailId || !isActiveStatus(activeDetailStatus)) return undefined;
+    const interval = setInterval(async () => {
+      try {
+        const data = await getVideoDetails({ admin, videoId: activeDetailId });
+        setDetail(data);
+        setDetailError("");
+      } catch (err) {
+        setDetailError(requestErrorMessage(err, "Could not refresh video details."));
+      }
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [activeDetailId, activeDetailStatus, admin]);
+
+  return {
+    actionError,
+    detail,
+    detailError,
+    clearActionError,
+    clearDetail,
+    loadDetail,
+    replaceDetail,
+    showActionError,
+  };
+}

--- a/react_frontend/src/hooks/useVideoLibrary.ts
+++ b/react_frontend/src/hooks/useVideoLibrary.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useMemo, useState, type MouseEvent } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import {
+  approveVideoUpload,
+  deleteVideoRecord,
+  listVideos,
+  requestErrorMessage,
+  updateVideoPublication,
+  updateVideoVisibility,
+} from "../api/client";
+import type { VideoSummary, VisibilityUpdate } from "../types";
+import { isActiveStatus } from "../utils/status";
+import { useAdminCatalogs } from "./useAdminCatalogs";
+import { useVideoDetailPolling } from "./useVideoDetailPolling";
+
+interface PlayingState {
+  resolution: string;
+  videoId: string;
+}
+
+export function useVideoLibrary(admin: boolean) {
+  const navigate = useNavigate();
+  const { videoId: routeVideoId } = useParams<{ videoId?: string }>();
+  const detailBasePath = admin ? "/manage" : "/library";
+  const [videos, setVideos] = useState<VideoSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [playing, setPlaying] = useState<PlayingState | null>(null);
+  const [approving, setApproving] = useState<string | null>(null);
+  const [publishing, setPublishing] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState("");
+  const {
+    catalogCopied,
+    catalogError,
+    catalogPublishing,
+    catalogs,
+    copyAddress,
+    loadCatalogs,
+    republishCatalogs,
+  } = useAdminCatalogs(admin);
+  const {
+    actionError,
+    clearActionError,
+    clearDetail,
+    detail,
+    detailError,
+    loadDetail,
+    replaceDetail,
+    showActionError,
+  } = useVideoDetailPolling({ admin, routeVideoId });
+  const detailId = detail?.id;
+  const playingVideoId = playing?.videoId;
+  const hasActiveVideos = useMemo(
+    () => videos.some((video) => isActiveStatus(video.status)),
+    [videos],
+  );
+  const videoCount = videos.length;
+
+  const load = useCallback(async () => {
+    try {
+      const data = await listVideos({ admin });
+      setVideos(data);
+      setLoadError("");
+    } catch (err) {
+      setLoadError(requestErrorMessage(err, "Could not load the video catalog."));
+    } finally {
+      setLoading(false);
+    }
+  }, [admin]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (hasActiveVideos) {
+        void load();
+      }
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [hasActiveVideos, load, videoCount]);
+
+  const openDetail = useCallback(async (videoId: string) => {
+    if (routeVideoId === videoId && detailId === videoId) {
+      navigate(detailBasePath);
+      return;
+    }
+    if (routeVideoId === videoId) {
+      await loadDetail(videoId);
+      return;
+    }
+    navigate(`${detailBasePath}/${encodeURIComponent(videoId)}`);
+  }, [detailBasePath, detailId, loadDetail, navigate, routeVideoId]);
+
+  const deleteVideo = useCallback(async (
+    videoId: string,
+    event: MouseEvent<HTMLButtonElement>,
+  ) => {
+    event.stopPropagation();
+    if (!window.confirm("Delete this video record and remove it from the network catalog?")) return;
+    clearActionError();
+    try {
+      await deleteVideoRecord(videoId);
+      setVideos((prev) => prev.filter((video) => video.id !== videoId));
+      await loadCatalogs();
+      if (detailId === videoId) {
+        clearDetail();
+        navigate(detailBasePath, { replace: true });
+      }
+      if (playingVideoId === videoId) setPlaying(null);
+    } catch (err) {
+      showActionError(requestErrorMessage(err, "Delete failed."));
+    }
+  }, [
+    clearActionError,
+    clearDetail,
+    detailId,
+    detailBasePath,
+    loadCatalogs,
+    navigate,
+    playingVideoId,
+    showActionError,
+  ]);
+
+  const approveVideo = useCallback(async (videoId: string) => {
+    setApproving(videoId);
+    clearActionError();
+    try {
+      const data = await approveVideoUpload(videoId);
+      replaceDetail(data);
+      await load();
+      await loadCatalogs();
+    } catch (err) {
+      const message = requestErrorMessage(err, "Approval failed.");
+      showActionError(message);
+      window.alert(message);
+    } finally {
+      setApproving(null);
+    }
+  }, [clearActionError, load, loadCatalogs, replaceDetail, showActionError]);
+
+  const updateVisibility = useCallback(async (videoId: string, next: VisibilityUpdate) => {
+    clearActionError();
+    try {
+      const data = await updateVideoVisibility(videoId, next);
+      replaceDetail(data);
+      setVideos((prev) => prev.map((video) => (
+        video.id === videoId ? { ...video, ...data } : video
+      )));
+      await loadCatalogs();
+    } catch (err) {
+      showActionError(requestErrorMessage(err, "Visibility update failed."));
+    }
+  }, [clearActionError, loadCatalogs, replaceDetail, showActionError]);
+
+  const updatePublication = useCallback(async (videoId: string, isPublic: boolean) => {
+    setPublishing(videoId);
+    clearActionError();
+    try {
+      const data = await updateVideoPublication(videoId, isPublic);
+      replaceDetail(data);
+      setVideos((prev) => prev.map((video) => (
+        video.id === videoId ? { ...video, ...data } : video
+      )));
+      await loadCatalogs();
+    } catch (err) {
+      showActionError(requestErrorMessage(err, isPublic ? "Publish failed." : "Unpublish failed."));
+    } finally {
+      setPublishing(null);
+    }
+  }, [clearActionError, loadCatalogs, replaceDetail, showActionError]);
+
+  return {
+    actionError,
+    approveVideo,
+    approving,
+    catalogCopied,
+    catalogError,
+    catalogPublishing,
+    catalogs,
+    copyAddress,
+    deleteVideo,
+    detail,
+    detailError,
+    loadError,
+    loading,
+    openDetail,
+    playing,
+    publishing,
+    republishCatalogs,
+    setPlaying,
+    updatePublication,
+    updateVisibility,
+    videos,
+  };
+}


### PR DESCRIPTION
## Summary
- Move library routing, polling, catalog, and mutation state into `useVideoLibrary`, `useVideoDetailPolling`, and `useAdminCatalogs`.
- Move HLS.js/native HLS playback recovery logic into `useHlsPlayback` and `useNativeHlsPlayback`.
- Keep Library and VideoPlayer rendering behavior intact while reducing component density.

## Validation
- `npm run lint`
- `npm run build`
- `CI=true npm test`
- Final stack: `make ci`