### PR TITLE
Add combined observability compose overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LOCAL_ENV ?= .env.local
 PROD_ENV ?= .env.production
 LOCAL_COMPOSE_FILES = -f docker-compose.yml -f docker-compose.local.yml
 LOCAL_MONITORING_COMPOSE_FILES = $(LOCAL_COMPOSE_FILES) -f docker-compose.monitoring.yml
-LOCAL_FULL_COMPOSE_FILES = $(LOCAL_MONITORING_COMPOSE_FILES) -f docker-compose.logging.yml
+LOCAL_FULL_COMPOSE_FILES = $(LOCAL_COMPOSE_FILES) -f docker-compose.observability.yml
 PROD_COMPOSE_FILES = -f docker-compose.yml -f docker-compose.prod.yml
 CORE_LOG_SERVICES = rust_admin rust_stream antd nginx react_frontend
 MONITORING_LOG_SERVICES = prometheus alertmanager grafana loki promtail
@@ -88,11 +88,17 @@ fmt-rust:
 compose-config:
 	$(DOCKER_COMPOSE) --env-file .env.local.example -f docker-compose.yml -f docker-compose.local.yml config >/tmp/autvid-compose-local.yml
 	$(DOCKER_COMPOSE) --env-file .env.local-public.example -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.local-public.yml config >/tmp/autvid-compose-local-public.yml
+	$(DOCKER_COMPOSE) --env-file .env.local.example $(LOCAL_MONITORING_COMPOSE_FILES) config >/tmp/autvid-compose-local-monitoring.yml
 	$(DOCKER_COMPOSE) --env-file .env.local.example $(LOCAL_FULL_COMPOSE_FILES) config >/tmp/autvid-compose-local-full.yml
 	$(DOCKER_COMPOSE) --env-file .env.local.example $(LOCAL_COMPOSE_FILES) -f docker-compose.backup.yml config >/tmp/autvid-compose-backup.yml
 	$(DOCKER_COMPOSE) --env-file .env.production.example -f docker-compose.yml -f docker-compose.prod.yml config >/tmp/autvid-compose-prod.yml
-	$(DOCKER_COMPOSE) --env-file .env.production.example -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.monitoring.yml -f docker-compose.logging.yml config >/tmp/autvid-compose-prod-observability.yml
+	$(DOCKER_COMPOSE) --env-file .env.production.example -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.observability.yml config >/tmp/autvid-compose-prod-observability.yml
 	$(DOCKER_COMPOSE) --env-file .env.production.example -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.backup.yml config >/tmp/autvid-compose-prod-backup.yml
+	grep -q "autvid_node_exporter" /tmp/autvid-compose-local-monitoring.yml
+	grep -q "autvid_node_exporter" /tmp/autvid-compose-local-full.yml
+	grep -q "autvid_promtail" /tmp/autvid-compose-local-full.yml
+	grep -q "autvid_promtail" /tmp/autvid-compose-prod-observability.yml
+	bash scripts/check-observability-overlay-parity.sh
 
 up-local:
 	$(DOCKER_COMPOSE) --env-file $(LOCAL_ENV) $(LOCAL_COMPOSE_FILES) up --build -d

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ autonomi-video-management/
 │       ├── App.jsx             # Root shell and tab composition
 │       ├── api/                # Axios API client wrappers
 │       ├── components/         # Upload, library, login, quote, and player components
-│       ├── hooks/              # Browser auth/session hooks
+│       ├── hooks/              # Browser auth/session, library, catalog, and playback hooks
 │       ├── styles/             # Split component-oriented CSS
 │       └── utils/              # Formatting, status, and resolution helpers
 ├── nginx/
@@ -565,6 +565,7 @@ autonomi-video-management/
 ├── docker-compose.local.yml    # Local self-contained Autonomi devnet overlay
 ├── docker-compose.debug-ports.yml # Optional direct admin/stream debug ports
 ├── docker-compose.prod.yml     # Production/default-network antd overlay
+├── docker-compose.observability.yml # Combined Prometheus/Grafana/Loki operations overlay
 ├── .env.local.example
 ├── .env.production.example
 └── .env.example

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,0 +1,121 @@
+services:
+  prometheus:
+    image: "${PROMETHEUS_IMAGE:-prom/prometheus:v2.55.1}"
+    container_name: autvid_prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
+    depends_on:
+      - rust_admin
+      - rust_stream
+    ports:
+      - "${PROMETHEUS_HTTP_BIND:-127.0.0.1}:${PROMETHEUS_HTTP_PORT:-9090}:9090"
+    networks:
+      - appnet
+    volumes:
+      - ./monitoring/prometheus:/etc/prometheus:ro
+      - prometheus_data:/prometheus
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+  node_exporter:
+    image: "${NODE_EXPORTER_IMAGE:-prom/node-exporter:v1.8.2}"
+    container_name: autvid_node_exporter
+    command:
+      - "--path.rootfs=/host"
+      - "--collector.textfile.directory=/textfile"
+      - "--collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/containers/storage/.+)($$|/)"
+    networks:
+      - appnet
+    volumes:
+      - /:/host:ro,rslave
+      - ${BACKUP_TEXTFILE_HOST_PATH:-./monitoring/textfile}:/textfile:ro
+    pid: host
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+  alertmanager:
+    image: "${ALERTMANAGER_IMAGE:-prom/alertmanager:v0.27.0}"
+    container_name: autvid_alertmanager
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+    ports:
+      - "${ALERTMANAGER_HTTP_BIND:-127.0.0.1}:${ALERTMANAGER_HTTP_PORT:-9093}:9093"
+    networks:
+      - appnet
+    volumes:
+      - ./monitoring/alertmanager:/etc/alertmanager:ro
+      - alertmanager_data:/alertmanager
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+  grafana:
+    image: "${GRAFANA_IMAGE:-grafana/grafana:11.3.0}"
+    container_name: autvid_grafana
+    depends_on:
+      - prometheus
+      - loki
+    environment:
+      GF_SECURITY_ADMIN_USER: "${GRAFANA_ADMIN_USER:-admin}"
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:-admin}"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "${GRAFANA_AUTH_ANONYMOUS_ENABLED:-false}"
+    ports:
+      - "${GRAFANA_HTTP_BIND:-127.0.0.1}:${GRAFANA_HTTP_PORT:-3000}:3000"
+    networks:
+      - appnet
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/etc/grafana/dashboards/autvid:ro
+      - ./monitoring/loki/grafana-datasource.yml:/etc/grafana/provisioning/datasources/loki.yml:ro
+      - grafana_data:/var/lib/grafana
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+  loki:
+    image: "${LOKI_IMAGE:-grafana/loki:2.9.8}"
+    container_name: autvid_loki
+    command:
+      - "-config.file=/etc/loki/config.yml"
+    ports:
+      - "${LOKI_HTTP_BIND:-127.0.0.1}:${LOKI_HTTP_PORT:-3100}:3100"
+    networks:
+      - appnet
+    volumes:
+      - ./monitoring/loki:/etc/loki:ro
+      - loki_data:/loki
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+  promtail:
+    image: "${PROMTAIL_IMAGE:-grafana/promtail:2.9.8}"
+    container_name: autvid_promtail
+    command:
+      - "-config.file=/etc/promtail/config.yml"
+    depends_on:
+      - loki
+    ports:
+      - "${PROMTAIL_HTTP_BIND:-127.0.0.1}:${PROMTAIL_HTTP_PORT:-9080}:9080"
+    networks:
+      - appnet
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./monitoring/promtail:/etc/promtail:ro
+      - promtail_positions:/run/promtail
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+
+volumes:
+  prometheus_data:
+  alertmanager_data:
+  grafana_data:
+  loki_data:
+  promtail_positions:

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,9 +1,9 @@
 # Observability
 
 The Compose stack can run optional Prometheus, Grafana, Alertmanager, Loki, and
-Promtail overlays. The metrics overlay scrapes the Rust services and `antd`
-gateway. The logging overlay tails Docker container logs into Loki for browsing
-from Grafana.
+Promtail services with `docker-compose.observability.yml`. Prometheus scrapes
+the Rust services and `antd` gateway. Promtail tails Docker container logs into
+Loki for browsing from Grafana.
 
 ## Metrics Endpoints
 
@@ -60,7 +60,17 @@ Stream-specific counters:
 
 ## Running Locally
 
-Start the local devnet stack with monitoring:
+Start the local devnet stack with metrics and log collection:
+
+```bash
+docker compose --env-file .env.local \
+  -f docker-compose.yml \
+  -f docker-compose.local.yml \
+  -f docker-compose.observability.yml \
+  up --build
+```
+
+For metrics only, use the split monitoring overlay:
 
 ```bash
 docker compose --env-file .env.local \
@@ -70,16 +80,11 @@ docker compose --env-file .env.local \
   up --build
 ```
 
-Start local monitoring plus log collection:
-
-```bash
-docker compose --env-file .env.local \
-  -f docker-compose.yml \
-  -f docker-compose.local.yml \
-  -f docker-compose.monitoring.yml \
-  -f docker-compose.logging.yml \
-  up --build
-```
+Do not combine `docker-compose.observability.yml` with
+`docker-compose.monitoring.yml` or `docker-compose.logging.yml` in the same
+command; those overlays intentionally define some of the same service and
+container names. `make compose-config` checks that shared image defaults stay
+aligned between the split and combined overlays.
 
 Open from the Docker host:
 
@@ -90,7 +95,7 @@ Open from the Docker host:
 | Alertmanager | `http://localhost:9093` | none |
 | Loki | `http://localhost:3100` | none |
 
-The monitoring and logging overlays bind their HTTP ports to `127.0.0.1` by
+The observability services bind their HTTP ports to `127.0.0.1` by
 default. Override the bind address only when another authenticated edge proxy,
 VPN, or private network protects these tools:
 
@@ -106,24 +111,24 @@ GRAFANA_ADMIN_PASSWORD=<change-me>
 LOKI_HTTP_BIND=127.0.0.1
 LOKI_HTTP_PORT=3101
 PROMTAIL_HTTP_BIND=127.0.0.1
-PROMTAIL_HTTP_PORT=9081
+PROMTAIL_HTTP_PORT=9080
 ```
 
 ## Running in Production
 
-Add the monitoring overlay to the production Compose command:
+Add the observability overlay to the production Compose command:
 
 ```bash
 docker compose --env-file .env.production \
   -f docker-compose.yml \
   -f docker-compose.prod.yml \
-  -f docker-compose.monitoring.yml \
+  -f docker-compose.observability.yml \
   up --build -d
 ```
 
-Add the logging overlay when you want centralized container logs in Loki and a
-provisioned `Loki` datasource in Grafana. It can run by itself for logs-only
-inspection, or after the monitoring overlay for metrics and logs together:
+The older split overlays remain available when you want metrics-only or
+logs-only inspection. Use these instead of the combined observability overlay,
+not alongside it:
 
 ```bash
 docker compose --env-file .env.production \
@@ -146,7 +151,7 @@ privileged.
 ## Grafana Dashboards
 
 Grafana is provisioned with a Prometheus datasource named `Prometheus`. When
-`docker-compose.logging.yml` is included, it also gets a `Loki` datasource.
+`docker-compose.observability.yml` is included, it also gets a `Loki` datasource.
 These dashboards are loaded in the `Autonomi Video Management` folder:
 
 | Dashboard | Coverage |
@@ -197,14 +202,13 @@ Render the merged Compose config before starting:
 docker compose --env-file .env.local \
   -f docker-compose.yml \
   -f docker-compose.local.yml \
-  -f docker-compose.monitoring.yml \
+  -f docker-compose.observability.yml \
   config
 
 docker compose --env-file .env.production \
   -f docker-compose.yml \
   -f docker-compose.prod.yml \
-  -f docker-compose.monitoring.yml \
-  -f docker-compose.logging.yml \
+  -f docker-compose.observability.yml \
   config
 ```
 

--- a/scripts/check-observability-overlay-parity.sh
+++ b/scripts/check-observability-overlay-parity.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+image_for_service() {
+  local file="$1"
+  local service="$2"
+
+  awk -v service="$service" '
+    $0 ~ "^[[:space:]][[:space:]]" service ":[[:space:]]*$" {
+      in_service = 1
+      next
+    }
+    in_service && /^[[:space:]][[:space:]][A-Za-z0-9_-]+:[[:space:]]*$/ {
+      in_service = 0
+    }
+    in_service && /^[[:space:]][[:space:]][[:space:]][[:space:]]image:[[:space:]]*/ {
+      sub(/^[[:space:]][[:space:]][[:space:]][[:space:]]image:[[:space:]]*/, "")
+      print
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        exit 1
+      }
+    }
+  ' "$file"
+}
+
+check_image_pin() {
+  local service="$1"
+  local split_file="$2"
+  local combined_file="$3"
+  local split_image
+  local combined_image
+
+  if ! split_image="$(image_for_service "$split_file" "$service")"; then
+    echo "Could not find image pin for ${service} in ${split_file}" >&2
+    exit 1
+  fi
+  if ! combined_image="$(image_for_service "$combined_file" "$service")"; then
+    echo "Could not find image pin for ${service} in ${combined_file}" >&2
+    exit 1
+  fi
+
+  if [[ "$split_image" != "$combined_image" ]]; then
+    echo "Observability image pin drift for ${service}:" >&2
+    echo "  ${split_file}: ${split_image}" >&2
+    echo "  ${combined_file}: ${combined_image}" >&2
+    exit 1
+  fi
+}
+
+combined_file="docker-compose.observability.yml"
+
+check_image_pin "prometheus" "docker-compose.monitoring.yml" "$combined_file"
+check_image_pin "node_exporter" "docker-compose.monitoring.yml" "$combined_file"
+check_image_pin "alertmanager" "docker-compose.monitoring.yml" "$combined_file"
+check_image_pin "grafana" "docker-compose.monitoring.yml" "$combined_file"
+check_image_pin "grafana" "docker-compose.logging.yml" "$combined_file"
+check_image_pin "loki" "docker-compose.logging.yml" "$combined_file"
+check_image_pin "promtail" "docker-compose.logging.yml" "$combined_file"


### PR DESCRIPTION
## Summary
- Add `docker-compose.observability.yml` combining Prometheus, Grafana, Alertmanager, Loki, and Promtail.
- Point `make up-local-full`, `make logs-monitoring`, and Compose validation at the combined overlay.
- Keep split monitoring/logging overlays available for metrics-only or logs-only use and update docs.

## Validation
- `make compose-config`
- `npm run lint`
- Final stack: `make ci`