### PR TITLE
Upgrade Debian runtime packages in Rust images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,22 @@ members = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+anyhow = "1"
+axum = "0.8"
+base64 = "0.22"
+bytes = "1"
+chrono = "0.4"
+reqwest = { version = "0.12", default-features = false }
+serde = "1"
+serde_json = "1"
+sha2 = "0.11"
+tokio = "1"
+tower-http = "0.6"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+uuid = "1"
+
 [profile.release]
 lto = "thin"
 codegen-units = 1

--- a/antd_service/Cargo.toml
+++ b/antd_service/Cargo.toml
@@ -4,26 +4,26 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
+anyhow.workspace = true
 ant-core = "=0.2.3"
 ant-node = "=0.11.2"
 autvid_common = { path = "../common" }
-axum = "0.8"
-base64 = "0.22"
-bytes = "1"
+axum.workspace = true
+base64.workspace = true
+bytes.workspace = true
 evmlib = "=0.8.1"
 hex = "0.4"
 futures-util = "0.3"
 rmp-serde = "1"
 self_encryption = "=0.35.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-sha2 = "0.11"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
 tempfile = "3"
 thiserror = "2"
-tokio = { version = "1", features = ["fs", "io-util", "macros", "rt-multi-thread", "signal"] }
-tower-http = { version = "0.6", features = ["cors", "request-id", "timeout", "trace", "util"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "rt-multi-thread", "signal"] }
+tower-http = { workspace = true, features = ["cors", "request-id", "timeout", "trace", "util"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 xor_name = "=5.0.0"
 zeroize = "1"

--- a/antd_service/Dockerfile
+++ b/antd_service/Dockerfile
@@ -32,7 +32,7 @@ RUN touch common/src/lib.rs antd_service/src/main.rs && cargo build --release -p
 # ── Stage 2: Minimal runtime ──────────────────────────────────────────────────
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
+anyhow.workspace = true
 http = "1"
 rand = "0.8"
-reqwest = { version = "0.12", default-features = false }
+reqwest.workspace = true
 subtle = "2"
-tokio = { version = "1", features = ["macros", "signal"] }
+tokio = { workspace = true, features = ["macros", "signal"] }

--- a/rust_admin/Cargo.toml
+++ b/rust_admin/Cargo.toml
@@ -7,22 +7,22 @@ edition = "2021"
 db-tests = []
 
 [dependencies]
-anyhow = "1"
+anyhow.workspace = true
 autvid_common = { path = "../common" }
-axum = { version = "0.8", features = ["macros", "multipart"] }
-base64 = "0.22"
-chrono = { version = "0.4", features = ["serde"] }
+axum = { workspace = true, features = ["macros", "multipart"] }
+base64.workspace = true
+chrono = { workspace = true, features = ["serde"] }
 fs2 = "0.4"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 rand = "0.8"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-sha2 = "0.11"
+reqwest = { workspace = true, features = ["json", "rustls-tls", "stream"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite", "uuid", "chrono", "json", "migrate", "macros"] }
-tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = { version = "0.7", features = ["io", "rt"] }
-tower-http = { version = "0.6", features = ["cors", "request-id", "timeout", "trace", "util"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-uuid = { version = "1", features = ["serde", "v4"] }
+tower-http = { workspace = true, features = ["cors", "request-id", "timeout", "trace", "util"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+uuid = { workspace = true, features = ["serde", "v4"] }

--- a/rust_admin/Dockerfile
+++ b/rust_admin/Dockerfile
@@ -32,7 +32,7 @@ RUN touch common/src/lib.rs rust_admin/src/main.rs && cargo build --release -p r
 # ── Stage 2: Runtime ──────────────────────────────────────────────────────────
 FROM debian:bookworm-slim
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \
     ffmpeg \
     libssl3 \

--- a/rust_stream/Cargo.toml
+++ b/rust_stream/Cargo.toml
@@ -5,24 +5,24 @@ edition = "2021"
 
 [dependencies]
 # HTTP server
-axum = { version = "0.8", features = ["macros"] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-tower-http = { version = "0.6", features = ["cors", "request-id", "timeout", "trace", "util"] }
+axum = { workspace = true, features = ["macros"] }
+reqwest = { workspace = true, features = ["json", "rustls-tls"] }
+tower-http = { workspace = true, features = ["cors", "request-id", "timeout", "trace", "util"] }
 
 # Async runtime
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 
 # Serialization
-base64 = "0.22"
-bytes = "1"
+base64.workspace = true
+bytes.workspace = true
 linked-hash-map = "0.5"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 
 # Logging
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 # Error handling
-anyhow = "1"
+anyhow.workspace = true
 autvid_common = { path = "../common" }

--- a/standalone_launcher/Cargo.toml
+++ b/standalone_launcher/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1"
-axum = "0.8"
+anyhow.workspace = true
+axum.workspace = true
 libc = "0.2"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
-tokio = { version = "1", features = ["fs", "macros", "net", "process", "rt-multi-thread", "signal", "time"] }
-tower-http = { version = "0.6", features = ["fs"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+reqwest = { workspace = true, features = ["rustls-tls", "stream"] }
+tokio = { workspace = true, features = ["fs", "macros", "net", "process", "rt-multi-thread", "signal", "time"] }
+tower-http = { workspace = true, features = ["fs"] }
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }


### PR DESCRIPTION
## Summary
- upgrade packages already present in the Debian runtime layers before installing runtime dependencies
- refreshes the rust_admin and antd_service images from Debian 12.13 to patched Debian 12.14 packages during build

## Validation
- docker build -t autvid-rust-admin:ci -f rust_admin/Dockerfile .
- docker build -t autvid-antd-service:ci -f antd_service/Dockerfile .
- docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --ignore-unfixed --severity CRITICAL,HIGH --exit-code 1 autvid-rust-admin:ci
- docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --ignore-unfixed --severity CRITICAL,HIGH --exit-code 1 autvid-antd-service:ci