### PR TITLE
Ignore macOS Finder metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,6 +173,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# macOS Finder metadata
+.DS_Store
+
 # PyPI configuration file
 .pypirc
 


### PR DESCRIPTION
## Summary
- Add .DS_Store to .gitignore so macOS Finder metadata files stay out of working tree changes.

## Validation
- git check-ignore -v .DS_Store rust_admin/.DS_Store react_frontend/.DS_Store