### PR TITLE
Fix local devnet Docker build

### DIFF
--- a/autonomi_devnet/Dockerfile
+++ b/autonomi_devnet/Dockerfile
@@ -34,11 +34,13 @@ COPY common/Cargo.toml common/Cargo.toml
 COPY rust_admin/Cargo.toml rust_admin/Cargo.toml
 COPY rust_stream/Cargo.toml rust_stream/Cargo.toml
 COPY antd_service/Cargo.toml antd_service/Cargo.toml
-RUN mkdir -p common/src rust_admin/src rust_stream/src antd_service/src && \
+COPY standalone_launcher/Cargo.toml standalone_launcher/Cargo.toml
+RUN mkdir -p common/src rust_admin/src rust_stream/src antd_service/src standalone_launcher/src && \
     echo "" > common/src/lib.rs && \
     echo "fn main(){}" > rust_admin/src/main.rs && \
     echo "fn main(){}" > rust_stream/src/main.rs && \
     echo "fn main(){}" > antd_service/src/main.rs && \
+    echo "fn main(){}" > standalone_launcher/src/main.rs && \
     cargo build --release -p antd
 
 COPY common/src common/src


### PR DESCRIPTION
## Summary
- include the standalone launcher manifest in the local devnet Docker dependency-cache stage
- add a placeholder launcher main so the workspace loads before building the antd gateway

## Verification
- docker compose --env-file .env.local -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.monitoring.yml -f docker-compose.logging.yml build antd