### PR TITLE
Fix monitoring compose overlay

### DIFF
--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -37,23 +37,9 @@ services:
     restart: unless-stopped
 
   grafana:
-    image: "${GRAFANA_IMAGE:-grafana/grafana:11.3.0}"
-    container_name: autvid_grafana
     depends_on:
+      - prometheus
       - loki
-    environment:
-      GF_SECURITY_ADMIN_USER: "${GRAFANA_ADMIN_USER:-admin}"
-      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:-admin}"
-      GF_USERS_ALLOW_SIGN_UP: "false"
-      GF_AUTH_ANONYMOUS_ENABLED: "${GRAFANA_AUTH_ANONYMOUS_ENABLED:-false}"
-    ports:
-      - "${GRAFANA_HTTP_BIND:-127.0.0.1}:${GRAFANA_HTTP_PORT:-3000}:3000"
-    networks:
-      - appnet
-    volumes:
-      - ./monitoring/loki/grafana-datasource.yml:/etc/grafana/provisioning/datasources/loki.yml:ro
-      - grafana_data:/var/lib/grafana
-    restart: unless-stopped
 
 volumes:
   grafana_data:

--- a/monitoring/grafana/provisioning/datasources/loki.yml
+++ b/monitoring/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true


### PR DESCRIPTION
## Summary
- provision Loki through Grafana's existing provisioning tree
- remove the nested Grafana datasource bind mount from the logging overlay

## Verification
- docker compose --env-file .env.local -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.monitoring.yml -f docker-compose.logging.yml config
- docker compose --env-file .env.local -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.monitoring.yml -f docker-compose.logging.yml up -d --force-recreate --remove-orphans