### PR TITLE
Update Autonomi tooling versions

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,9 +7,9 @@ ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH="/opt/venv/bin:${PATH}:/opt/mssql-tools18/bin:${CARGO_HOME}/bin"
 
 # Keep the Autonomi toolchain on a single ant-node/protocol line.
-ARG AUTONOMI_ANT_SDK_REF=v0.6.1
-ARG AUTONOMI_ANT_CLIENT_REF=ant-cli-v0.2.2
-ARG AUTONOMI_ANT_NODE_REF=v0.11.1
+ARG AUTONOMI_ANT_SDK_REF=v0.9.2
+ARG AUTONOMI_ANT_CLIENT_REF=ant-cli-v0.2.7
+ARG AUTONOMI_ANT_NODE_REF=v0.12.0
 
 # Install all system packages and tools in fewer layers
 RUN rm -f /etc/apt/sources.list.d/yarn.list \
@@ -29,6 +29,7 @@ python3-venv \
 build-essential \
 python3-dev \
 libssl-dev \
+liblzma-dev \
 protobuf-compiler \
 docker.io \
 ripgrep \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,21 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes-gcm-siv"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "polyval",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,13 +813,14 @@ dependencies = [
 
 [[package]]
 name = "ant-core"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbf7d5a9bad0fe74bb3995311ed7d65221b51d001eee6e038a634690db2c447"
+checksum = "28a73da60002c4da9d379264a955a8fca2e090d3d9ced3a5ffacbb6c3e87a205"
 dependencies = [
  "ant-protocol",
  "async-stream",
  "axum",
+ "blake3",
  "bytes",
  "flate2",
  "fs2",
@@ -881,11 +867,10 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.11.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2cc06c786666f4ce514cfe68b3add6c62176f1411a40ebbbe2adae259121222"
+checksum = "be733b3b7f5b255fae1a315e24127e385c845677cd7aba1f1cde19e791f04976"
 dependencies = [
- "aes-gcm-siv",
  "ant-protocol",
  "blake3",
  "bytes",
@@ -899,8 +884,9 @@ dependencies = [
  "futures",
  "heed",
  "hex",
- "hkdf",
+ "libc",
  "lru",
+ "mimalloc",
  "objc2",
  "objc2-foundation",
  "page_size",
@@ -912,7 +898,6 @@ dependencies = [
  "saorsa-core",
  "saorsa-pqc 0.5.1",
  "self-replace",
- "self_encryption",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -932,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d0ba3f671c08a1d52291b601ec35a7353f4f4e10f221b5f0ee372d154636dd"
+checksum = "9e950d12c9f6d08d0ea560573729d93f15e105d53b669defa682f5e6f92da4b1"
 dependencies = [
  "blake3",
  "bytes",
@@ -3375,7 +3360,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -3831,6 +3816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3982,6 +3976,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -5546,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.4"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1267928da1bcc91748c314f95f7952bc01c0359a4ac70a0b111b0386898934"
+checksum = "3c0f8952fc5a4d37eb0bca7de0740830f40347f9da663effde3ddd6b68bcd2fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5830,9 +5833,9 @@ dependencies = [
 
 [[package]]
 name = "self_encryption"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c11020d59e8e663ba591026c2b45a08caa74a3a654ac12b2532d5a7c5b97e510"
+checksum = "47ab904569f88dcbde4f0feadb693c184577dc81e8243f96bb725e72a779c637"
 dependencies = [
  "bincode",
  "blake3",

--- a/antd_service/Cargo.toml
+++ b/antd_service/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-ant-core = "=0.2.4"
-ant-node = "=0.11.4"
+ant-core = "=0.2.7"
+ant-node = "=0.12.0"
 autvid_common = { path = "../common" }
 axum.workspace = true
 base64.workspace = true
@@ -15,7 +15,7 @@ evmlib = "=0.8.1"
 hex = "0.4"
 futures-util = "0.3"
 rmp-serde = "1"
-self_encryption = "=0.35.0"
+self_encryption = "=0.36.0"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true

--- a/antd_service/Dockerfile
+++ b/antd_service/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     git \
     libssl-dev \
+    liblzma-dev \
     pkg-config \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*

--- a/antd_service/Dockerfile
+++ b/antd_service/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
     git \
     libssl-dev \
     liblzma-dev \
+    perl \
     pkg-config \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
@@ -35,6 +36,7 @@ FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     ca-certificates \
+    liblzma5 \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/autonomi_devnet/Dockerfile
+++ b/autonomi_devnet/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     git \
     libssl-dev \
     liblzma-dev \
+    perl \
     pkg-config \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
@@ -58,6 +59,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     curl \
     jq \
+    liblzma5 \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/autonomi_devnet/Dockerfile
+++ b/autonomi_devnet/Dockerfile
@@ -1,13 +1,14 @@
 # ── Stage 1: Build local Autonomi devnet tooling ─────────────────────────────
 FROM rust:1.95-slim-bookworm AS builder
 
-ARG AUTONOMI_ANT_SDK_REF=v0.6.1
-ARG AUTONOMI_ANT_NODE_REF=v0.11.4
+ARG AUTONOMI_ANT_SDK_REF=v0.9.2
+ARG AUTONOMI_ANT_NODE_REF=v0.12.0
 
 RUN apt-get update && apt-get install -y \
     build-essential \
     git \
     libssl-dev \
+    liblzma-dev \
     pkg-config \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- bump pinned Autonomi crates for the antd service to ant-core 0.2.7, ant-node 0.12.0, and self_encryption 0.36.0
- update Docker/devcontainer Autonomi tooling refs to ant-sdk v0.9.2, ant-cli v0.2.7, and ant-node v0.12.0
- add liblzma-dev to Rust build images for the refreshed Autonomi dependency graph

## Version sources
- crates.io latest non-yanked releases: ant-core 0.2.7, ant-node 0.12.0, self_encryption 0.36.0
- upstream tags: WithAutonomi/ant-sdk v0.9.2, WithAutonomi/ant-client ant-cli-v0.2.7, WithAutonomi/ant-node v0.12.0

## Verification
- docker run rust:1.96-slim-bookworm cargo test -p antd after installing pkg-config libssl-dev protobuf-compiler liblzma-dev: 9 passed
- make devbench-build
- make compose-config
- make devbench-up: local Autonomi devnet and antd REST health ready, antd version 0.9.2
- make devbench-exec ARGS='make test-antd': 9 passed
- make devbench-down

## Notes
- A first Docker test without liblzma-dev failed at link time with missing -llzma; this PR adds the native package wherever the refreshed Autonomi Rust graph is built.
