### PR TITLE
Add headless devcontainer test bench

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ ARG AUTONOMI_ANT_NODE_REF=v0.12.0
 
 # Install all system packages and tools in fewer layers
 RUN rm -f /etc/apt/sources.list.d/yarn.list \
-&& apt-get update && apt-get install -y \
+&& apt-get update && apt-get install -y --no-install-recommends \
 curl \
 wget \
 git \
@@ -31,7 +31,6 @@ python3-dev \
 libssl-dev \
 liblzma-dev \
 protobuf-compiler \
-docker.io \
 ripgrep \
 dnsutils \
 net-tools \
@@ -44,7 +43,21 @@ htop \
 tree \
 tcpdump \
 ffmpeg \
-&& rm -rf /var/lib/apt/lists/*
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+# Install the Docker CLI only. The container talks to OrbStack through the
+# mounted host socket, so it does not need a Docker daemon/containerd stack.
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+&& curl -fsSL https://download.docker.com/linux/debian/gpg \
+  > /etc/apt/keyrings/docker.asc \
+&& chmod a+r /etc/apt/keyrings/docker.asc \
+&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian bookworm stable" \
+  > /etc/apt/sources.list.d/docker.list \
+&& apt-get update \
+&& apt-get install -y --no-install-recommends docker-ce-cli \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Install GitHub CLI from the official apt repository so PR/review workflows
 # are available after every devcontainer rebuild.
@@ -55,24 +68,26 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
 && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
   > /etc/apt/sources.list.d/github-cli.list \
 && apt-get update \
-&& apt-get install -y gh \
-&& rm -rf /var/lib/apt/lists/*
+&& apt-get install -y --no-install-recommends gh \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Install Node.js 24 and the Python package runner used by MCP helpers.
 RUN mkdir -p /etc/apt/keyrings \
 && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
 && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
 && apt-get update \
-&& apt-get install -y nodejs \
+&& apt-get install -y --no-install-recommends nodejs \
 && pip install --no-cache-dir uv \
 && ln -s /usr/bin/fdfind /usr/local/bin/fd \
 && ln -s /usr/bin/batcat /usr/local/bin/bat \
-&& rm -rf /var/lib/apt/lists/*
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # Install Rust and Rust development tools
 RUN mkdir -p "${CARGO_HOME}" "${RUSTUP_HOME}" \
 && chmod -R a+rwX "${CARGO_HOME}" "${RUSTUP_HOME}" \
-&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path \
+&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal \
 && rustup component add rustfmt clippy \
 && cargo install cargo-edit cargo-outdated \
 && PW_ARCH="$(dpkg --print-architecture)" \
@@ -91,7 +106,7 @@ esac \
 && rm -f /tmp/powershell.tar.gz \
 && pwsh --version \
 && chmod -R a+rwX "${CARGO_HOME}" "${RUSTUP_HOME}" \
-&& rm -rf /var/lib/apt/lists/*
+&& rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache /tmp/*
 
 # Build and install antd (Autonomi daemon), the Autonomi MCP server, and the
 # dev CLI support libraries from ant-sdk in a single layer to share the cargo cache.
@@ -105,7 +120,8 @@ RUN git clone https://github.com/WithAutonomi/ant-sdk.git && \
     pip install --no-cache-dir ".[rest]" && \
     cd ../antd-mcp && \
     pip install --no-cache-dir . && \
-    cd ../.. && rm -rf ant-sdk
+    cd ../.. && \
+    rm -rf ant-sdk "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache /tmp/*
 
 # Build and install ant (Autonomi CLI)
 RUN git clone https://github.com/WithAutonomi/ant-client.git && \
@@ -113,7 +129,8 @@ RUN git clone https://github.com/WithAutonomi/ant-client.git && \
     git checkout "$AUTONOMI_ANT_CLIENT_REF" && \
     cargo build --release --bin ant && \
     cp target/release/ant /usr/local/bin/ && \
-    cd .. && rm -rf ant-client
+    cd .. && \
+    rm -rf ant-client "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache /tmp/*
 
 # Build ant-devnet from ant-node — required for the local devnet used in development.
 # ant dev start normally does this via `cargo run`; we pre-build it here so startup
@@ -123,7 +140,8 @@ RUN git clone https://github.com/WithAutonomi/ant-node.git && \
     git checkout "$AUTONOMI_ANT_NODE_REF" && \
     cargo build --release --bin ant-devnet && \
     cp target/release/ant-devnet /usr/local/bin/ && \
-    cd .. && rm -rf ant-node
+    cd .. && \
+    rm -rf ant-node "${CARGO_HOME}/registry" "${CARGO_HOME}/git" /root/.cache /tmp/*
 
 # Install Foundry (anvil) — required by ant-devnet to run the local EVM chain.
 # Downloads pre-built binaries directly from GitHub releases (more reliable in Docker
@@ -138,8 +156,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
     { [ -n "$FOUNDRY_TAG" ] || { echo "ERROR: could not determine Foundry release tag" >&2; exit 1; }; } && \
     curl -fsSLo /tmp/foundry.tar.gz \
       "https://github.com/foundry-rs/foundry/releases/download/${FOUNDRY_TAG}/foundry_${FOUNDRY_TAG}_linux_${FOUNDRY_ARCH}.tar.gz" && \
-    tar -xzf /tmp/foundry.tar.gz -C /usr/local/bin anvil forge cast chisel && \
-    rm /tmp/foundry.tar.gz && \
+    tar -xzf /tmp/foundry.tar.gz -C /tmp anvil && \
+    install -m 0755 /tmp/anvil /usr/local/bin/anvil && \
+    rm -f /tmp/foundry.tar.gz /tmp/anvil && \
     anvil --version
 
 # Create docker group and add vscode so the Docker socket (mounted from OrbStack
@@ -181,8 +200,9 @@ RUN mkdir -p /usr/libexec/docker/cli-plugins && \
     chmod +x /usr/libexec/docker/cli-plugins/docker-compose && \
     rm -f /tmp/docker-compose-release.json
 
-# Keep the shared Rust toolchain/cache usable from the non-root dev user.
-RUN chmod -R a+rwX "${CARGO_HOME}" "${RUSTUP_HOME}"
+# Keep the shared Rust toolchain/cache discoverable from login shells.
+RUN printf '%s\n' 'export PATH="/opt/venv/bin:/usr/local/python/current/bin:/usr/local/py-utils/bin:/usr/local/jupyter:/usr/local/share/nvm/current/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/mssql-tools18/bin:/usr/local/cargo/bin:$PATH"' \
+  > /etc/profile.d/00-devcontainer-path.sh
 
 # Set working directory
 WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -82,7 +82,7 @@
           ]
         },
         "kubernetes": {
-          "command": "/home/vscode/.local/bin/uvx",
+          "command": "/usr/local/bin/uvx",
           "args": [
             "--native-tls",
             "mcp-server-kubernetes"
@@ -92,14 +92,67 @@
           "command": "npx",
           "args": [
             "-y",
-            "@modelcontextprotocol/server-brave-search"
+            "@brave/brave-search-mcp-server"
           ],
           "env": {
             "BRAVE_API_KEY": "${env:BRAVE_API_KEY}"
           }
         },
         "antd-autonomi": {
-          "command": "antd-mcp"
+          "command": "antd-mcp",
+          "env": {
+            "ANTD_BASE_URL": "http://127.0.0.1:8082",
+            "ALL_PROXY": "",
+            "all_proxy": "",
+            "HTTP_PROXY": "",
+            "http_proxy": "",
+            "HTTPS_PROXY": "",
+            "https_proxy": "",
+            "NO_PROXY": "localhost,127.0.0.1",
+            "no_proxy": "localhost,127.0.0.1"
+          }
+        }
+      }
+    },
+    "codex": {
+      "mcpServers": {
+        "github": {
+          "url": "https://api.githubcopilot.com/mcp/",
+          "bearer_token_env_var": "GITHUB_TOKEN"
+        },
+        "git-repo-research": {
+          "enabled": false
+        },
+        "context7": {
+          "url": "https://mcp.context7.com/mcp"
+        },
+        "memory": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "@modelcontextprotocol/server-memory"
+          ]
+        },
+        "postgres": {
+          "command": "/bin/bash",
+          "args": [
+            "-lc",
+            "exec npx -y @modelcontextprotocol/server-postgres \"${DATABASE_URL:-postgresql://postgres:RootPassword@127.0.0.1:5432/postgres}\""
+          ]
+        },
+        "antd-autonomi": {
+          "command": "antd-mcp",
+          "env": {
+            "ANTD_BASE_URL": "http://127.0.0.1:8082",
+            "ALL_PROXY": "",
+            "all_proxy": "",
+            "HTTP_PROXY": "",
+            "http_proxy": "",
+            "HTTPS_PROXY": "",
+            "https_proxy": "",
+            "NO_PROXY": "localhost,127.0.0.1",
+            "no_proxy": "localhost,127.0.0.1"
+          }
         }
       }
     },
@@ -141,17 +194,15 @@
             "args": ["--native-tls", "mcp-server-git", "--repository", "${containerWorkspaceFolder}"]
           },
           "github": {
-            "type": "stdio",
-            "command": "/usr/local/bin/uvx",
-            "args": ["--native-tls", "mcp-server-github"],
-            "env": {
-              "GITHUB_TOKEN": "${env:GITHUB_TOKEN}"
-            }
+            "url": "https://api.githubcopilot.com/mcp/"
           },
           "postgres": {
             "type": "stdio",
-            "command": "/usr/local/bin/uvx",
-            "args": ["--native-tls", "mcp-server-postgres", "${env:DATABASE_URL}"]
+            "command": "/bin/bash",
+            "args": [
+              "-lc",
+              "exec npx -y @modelcontextprotocol/server-postgres \"${DATABASE_URL:-postgresql://postgres:RootPassword@127.0.0.1:5432/postgres}\""
+            ]
           },
           "docker": {
             "type": "stdio",
@@ -160,8 +211,8 @@
           },
           "memory": {
             "type": "stdio",
-            "command": "/usr/local/bin/uvx",
-            "args": ["--native-tls", "mcp-server-memory"]
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-memory"]
           },
           "sequential-thinking": {
             "type": "stdio",
@@ -170,20 +221,34 @@
           },
           "kubernetes": {
             "type": "stdio",
-            "command": "/home/vscode/.local/bin/uvx",
+            "command": "/usr/local/bin/uvx",
             "args": ["--native-tls", "mcp-server-kubernetes"]
           },
           "brave-search": {
             "type": "stdio",
             "command": "npx",
-            "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+            "args": ["-y", "@brave/brave-search-mcp-server"],
             "env": {
               "BRAVE_API_KEY": "${env:BRAVE_API_KEY}"
             }
           },
+          "context7": {
+            "url": "https://mcp.context7.com/mcp"
+          },
           "antd-autonomi": {
             "type": "stdio",
-            "command": "antd-mcp"
+            "command": "antd-mcp",
+            "env": {
+              "ANTD_BASE_URL": "http://127.0.0.1:8082",
+              "ALL_PROXY": "",
+              "all_proxy": "",
+              "HTTP_PROXY": "",
+              "http_proxy": "",
+              "HTTPS_PROXY": "",
+              "https_proxy": "",
+              "NO_PROXY": "localhost,127.0.0.1",
+              "no_proxy": "localhost,127.0.0.1"
+            }
           }
         }
       }
@@ -196,13 +261,18 @@
     "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
     "source=${localEnv:HOME}/.devcontainer_bash_history,target=/home/vscode/.bash_history,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached",
-    "source=${localEnv:HOME}/.codex,target=/home/vscode/.codex,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.codex_vscode,target=/home/vscode/.codex,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.config/gh,target=/home/vscode/.config/gh,type=bind,consistency=cached"
   ],
+  "containerEnv": {
+    "BRAVE_API_KEY": "${localEnv:BRAVE_API_KEY}",
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
+  },
   "remoteEnv": {
     "HISTFILE": "/home/vscode/.bash_history",
     "PROMPT_COMMAND": "history -a",
     "BRAVE_API_KEY": "${localEnv:BRAVE_API_KEY}",
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
     "ANTD_NETWORK": "local",
     "AUTONOMI_WALLET_KEY": "${localEnv:AUTONOMI_WALLET_KEY}"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,10 @@ cython_debug/
 # macOS Finder metadata
 .DS_Store
 
+# Local agent steering files
+AGENTS.md
+CLAUDE.md
+
 # PyPI configuration file
 .pypirc
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,0 @@
-# Project Notes
-
-- Release builds use `panic = "abort"` workspace-wide; do not rely on `catch_unwind` boundaries in release behavior.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install-react test test-rust test-rust-workspace test-rust-stream test-rust-admin test-rust-db test-antd clippy-rust clippy-rust-workspace clippy-rust-stream clippy-rust-admin clippy-antd fmt-rust compose-config up-local up-local-full up-prod down-local down-prod logs logs-prod logs-monitoring backup-production restore-production lint-react test-react coverage-react build-react smoke-local smoke-local-restart smoke-local-large-original audit-rust audit-react audit-trivy audit ci
+.PHONY: help install-react test test-rust test-rust-workspace test-rust-stream test-rust-admin test-rust-db test-antd clippy-rust clippy-rust-workspace clippy-rust-stream clippy-rust-admin clippy-antd fmt-rust compose-config up-local up-local-full up-prod down-local down-prod logs logs-prod logs-monitoring devbench-build devbench-up devbench-down devbench-restart devbench-status devbench-shell devbench-exec backup-production restore-production lint-react test-react coverage-react build-react smoke-local smoke-local-restart smoke-local-large-original audit-rust audit-react audit-trivy audit ci
 
 NPM ?= npm
 CARGO ?= cargo
@@ -35,6 +35,10 @@ help:
 	@echo "  make logs            Follow local core service logs"
 	@echo "  make logs-prod       Follow production core service logs"
 	@echo "  make logs-monitoring Follow local monitoring service logs"
+	@echo "  make devbench-up     Run the VS Code devcontainer image headlessly"
+	@echo "  make devbench-shell  Open a shell in the headless devcontainer test bench"
+	@echo "  make devbench-exec ARGS='make test-rust' Run a command in the headless devcontainer"
+	@echo "  make devbench-down   Stop the headless devcontainer test bench"
 	@echo "  make backup-production Create a timestamped production SQLite/catalog backup"
 	@echo "  make restore-production ARGS='--backup-dir backups/autvid-... --yes' Restore a production backup"
 	@echo "  make install-react   Install React frontend dependencies"
@@ -117,6 +121,28 @@ logs-prod:
 
 logs-monitoring:
 	$(DOCKER_COMPOSE) --env-file $(LOCAL_ENV) $(LOCAL_FULL_COMPOSE_FILES) logs -f $(MONITORING_LOG_SERVICES)
+
+devbench-build:
+	scripts/devcontainer-testbench.sh build
+
+devbench-up:
+	scripts/devcontainer-testbench.sh up
+
+devbench-down:
+	scripts/devcontainer-testbench.sh down
+
+devbench-restart:
+	scripts/devcontainer-testbench.sh restart
+
+devbench-status:
+	scripts/devcontainer-testbench.sh status
+
+devbench-shell:
+	scripts/devcontainer-testbench.sh shell
+
+devbench-exec:
+	@test -n "$(ARGS)" || { echo "Usage: make devbench-exec ARGS='make test-rust'"; exit 2; }
+	scripts/devcontainer-testbench.sh exec $(ARGS)
 
 backup-production:
 	scripts/backup-production.sh

--- a/README.md
+++ b/README.md
@@ -88,7 +88,54 @@ Monitoring and logging overlay ports bind to localhost by default.
 
 ## Quick start (development)
 
-The project ships with a devcontainer that handles the full local setup automatically, including a local Autonomi testnet with a pre-funded test wallet.
+The project ships with two development paths:
+
+- A headless Docker Compose test bench for running the app and smoke tests without VS Code.
+- A VS Code devcontainer for editor-integrated development when you want it.
+
+### Headless test bench
+
+This is the preferred path for agent-driven work from Codex. It starts the
+runtime stack directly with Docker Compose and does not require VS Code to be
+open.
+
+```bash
+cp .env.local.example .env.local
+make up-local
+make smoke-local
+make down-local
+```
+
+Useful variants:
+
+```bash
+make up-local-full
+make smoke-local-restart
+make smoke-local-large-original
+make logs
+```
+
+If you specifically want the same devcontainer image that VS Code uses, but
+without starting VS Code, use the headless devcontainer test bench:
+
+```bash
+make devbench-up
+make devbench-exec ARGS='make test-rust'
+make devbench-shell
+make devbench-down
+```
+
+`devbench-up` builds the same `.devcontainer/Dockerfile`, mounts the repository
+at `/workspace`, forwards the core container ports to alternate host ports by
+default (`18082` for `antd` REST), passes through useful host tokens such as
+`GITHUB_TOKEN` and `BRAVE_API_KEY`, and runs the same
+`.devcontainer/post_start.sh` startup hook.
+
+### VS Code devcontainer
+
+The devcontainer remains available for VS Code workflows and handles the full
+local setup automatically, including a local Autonomi testnet with a pre-funded
+test wallet.
 
 ### Prerequisites
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (or Docker Engine + Docker Compose)

--- a/scripts/devcontainer-testbench.sh
+++ b/scripts/devcontainer-testbench.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+IMAGE="${DEVBENCH_IMAGE:-autvid-devcontainer-testbench}"
+CONTAINER="${DEVBENCH_CONTAINER:-autvid_devcontainer_testbench}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKSPACE="${DEVBENCH_WORKSPACE:-/workspace}"
+DEV_PATH="/opt/venv/bin:/usr/local/python/current/bin:/usr/local/py-utils/bin:/usr/local/jupyter:/usr/local/share/nvm/current/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/mssql-tools18/bin:/usr/local/cargo/bin"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/devcontainer-testbench.sh <command> [args...]
+
+Run the VS Code devcontainer image as a headless Codex test bench.
+
+Commands:
+  build             Build the devcontainer image
+  up                Start the detached test bench and run postStart setup
+  down              Stop and remove the detached test bench
+  restart           Recreate the detached test bench
+  status            Show container status and key environment checks
+  shell             Open an interactive shell as the vscode user
+  exec <cmd...>     Run a command as the vscode user
+  logs              Show recent container logs
+
+Environment:
+  DEVBENCH_IMAGE      Docker image tag. Default: autvid-devcontainer-testbench
+  DEVBENCH_CONTAINER  Container name. Default: autvid_devcontainer_testbench
+
+The script keeps VS Code devcontainers working by using the same Dockerfile, but
+it does not require VS Code to be open.
+USAGE
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 127
+  }
+}
+
+host_env() {
+  local name="$1"
+  local value="${!name:-}"
+  if [[ -z "$value" && "$(uname -s)" == "Darwin" ]] && command -v launchctl >/dev/null 2>&1; then
+    value="$(launchctl getenv "$name" 2>/dev/null || true)"
+  fi
+  if [[ -z "$value" && "$name" == "GITHUB_TOKEN" ]] && command -v gh >/dev/null 2>&1; then
+    value="$(gh auth token 2>/dev/null || true)"
+  fi
+  printf '%s' "$value"
+}
+
+docker_sock_args() {
+  if [[ -S /var/run/docker.sock ]]; then
+    printf '%s\n' "-v" "/var/run/docker.sock:/var/run/docker.sock"
+  fi
+}
+
+optional_home_mount_args() {
+  local source="$1"
+  local target="$2"
+  if [[ -e "$source" ]]; then
+    printf '%s\n' "-v" "${source}:${target}:cached"
+  fi
+}
+
+container_exists() {
+  docker container inspect "$CONTAINER" >/dev/null 2>&1
+}
+
+container_running() {
+  [[ "$(docker container inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || true)" == "true" ]]
+}
+
+build_image() {
+  need docker
+  docker build -t "$IMAGE" -f "$ROOT_DIR/.devcontainer/Dockerfile" "$ROOT_DIR/.devcontainer"
+}
+
+start_container() {
+  need docker
+  if container_running; then
+    echo "$CONTAINER is already running"
+    return 0
+  fi
+  if container_exists; then
+    docker rm "$CONTAINER" >/dev/null
+  fi
+
+  local github_token brave_api_key autonomi_wallet_key
+  github_token="$(host_env GITHUB_TOKEN)"
+  brave_api_key="$(host_env BRAVE_API_KEY)"
+  autonomi_wallet_key="$(host_env AUTONOMI_WALLET_KEY)"
+
+  local -a args=(
+    run -d
+    --name "$CONTAINER"
+    --workdir "$WORKSPACE"
+    -v "$ROOT_DIR:$WORKSPACE:cached"
+    -e ANTD_NETWORK="${ANTD_NETWORK:-local}"
+    -e PATH="$DEV_PATH"
+    -e GITHUB_TOKEN="$github_token"
+    -e BRAVE_API_KEY="$brave_api_key"
+    -e AUTONOMI_WALLET_KEY="$autonomi_wallet_key"
+    -p "${DEVBENCH_HTTP_PORT:-18080}:80"
+    -p "${DEVBENCH_ADMIN_PORT:-18000}:8000"
+    -p "${DEVBENCH_STREAM_PORT:-18081}:8081"
+    -p "${DEVBENCH_ANTD_REST_PORT:-18082}:8082"
+    -p "${DEVBENCH_ANTD_GRPC_PORT:-15051}:50051"
+  )
+
+  while IFS= read -r item; do args+=("$item"); done < <(docker_sock_args)
+  while IFS= read -r item; do args+=("$item"); done < <(optional_home_mount_args "$HOME/.claude" /home/vscode/.claude)
+  while IFS= read -r item; do args+=("$item"); done < <(optional_home_mount_args "$HOME/.codex_vscode" /home/vscode/.codex)
+  while IFS= read -r item; do args+=("$item"); done < <(optional_home_mount_args "$HOME/.config/gh" /home/vscode/.config/gh)
+
+  args+=("$IMAGE" sleep infinity)
+  docker "${args[@]}" >/dev/null
+
+  docker exec --user vscode "$CONTAINER" bash -lc "export PATH='$DEV_PATH'; cd '$WORKSPACE' && bash .devcontainer/post_start.sh"
+}
+
+stop_container() {
+  need docker
+  if container_exists; then
+    docker rm -f "$CONTAINER" >/dev/null
+  fi
+}
+
+status_container() {
+  need docker
+  docker ps --filter "name=^/${CONTAINER}$" --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'
+  if container_running; then
+    docker exec --user vscode "$CONTAINER" bash -lc '
+      export PATH='"$DEV_PATH"'
+      test -n "$GITHUB_TOKEN" && echo "GITHUB_TOKEN=set" || echo "GITHUB_TOKEN=missing"
+      test -n "$BRAVE_API_KEY" && echo "BRAVE_API_KEY=set" || echo "BRAVE_API_KEY=missing"
+      curl -fsS --max-time 2 http://localhost:8082/health >/dev/null && echo "antd=healthy" || echo "antd=not-ready"
+    '
+  fi
+}
+
+case "${1:-}" in
+  build)
+    build_image
+    ;;
+  up)
+    build_image
+    start_container
+    ;;
+  down)
+    stop_container
+    ;;
+  restart)
+    stop_container
+    build_image
+    start_container
+    ;;
+  status)
+    status_container
+    ;;
+  shell)
+    need docker
+    container_running || start_container
+    docker exec -it --user vscode "$CONTAINER" bash -lc "export PATH='$DEV_PATH'; cd '$WORKSPACE' && exec bash"
+    ;;
+  exec)
+    shift
+    [[ $# -gt 0 ]] || { echo "Usage: $0 exec <cmd...>" >&2; exit 2; }
+    need docker
+    container_running || start_container
+    docker exec --user vscode "$CONTAINER" bash -lc "export PATH='$DEV_PATH'; cd '$WORKSPACE' && exec \"\$@\"" bash "$@"
+    ;;
+  logs)
+    need docker
+    docker logs "$CONTAINER" "${@:2}"
+    ;;
+  --help|-h|help|"")
+    usage
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Add Makefile targets and a `scripts/devcontainer-testbench.sh` helper for running the VS Code devcontainer image headlessly.
- Tighten the devcontainer image by using slimmer apt installs, Docker CLI-only install, smaller Foundry extraction, cache cleanup, and explicit path setup.
- Refresh devcontainer MCP configuration for Codex/Claude, Autonomi MCP proxy settings, GitHub Copilot MCP, Context7, Brave Search, and mounted credentials.
- Document the headless test bench workflow in the README.
- Stop tracking `CLAUDE.md` and add both `AGENTS.md` and `CLAUDE.md` to `.gitignore` so local agent steering files stay local.

## Verification

- `bash -n scripts/devcontainer-testbench.sh`
- `make devbench-build`
- `make devbench-up && make devbench-status && make devbench-down`
  - `antd` reported healthy in the headless devbench container.
- `git diff --check origin/main...HEAD`

## Review Notes

Claude review was attempted for this branch with the working Sonnet fallback after Opus stalled earlier today, but the Sonnet CLI process also produced no output after several minutes and was stopped. No Claude findings were available to address. I performed a local review and the Docker/devbench validation above.
