### PR TITLE
[codex] Fix local proxy validation paths

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,7 +172,7 @@ services:
     expose:
       - "8080"
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8080/"]
+      test: ["CMD-SHELL", "env -u http_proxy -u HTTP_PROXY -u https_proxy -u HTTPS_PROXY -u all_proxy -u ALL_PROXY wget -q -O /dev/null http://127.0.0.1:8080/"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -204,7 +204,7 @@ services:
     networks:
       - appnet
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:8080/"]
+      test: ["CMD-SHELL", "env -u http_proxy -u HTTP_PROXY -u https_proxy -u HTTPS_PROXY -u all_proxy -u ALL_PROXY wget -q -O /dev/null http://127.0.0.1:8080/"]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/react_frontend/src/__tests__/setup.ts
+++ b/react_frontend/src/__tests__/setup.ts
@@ -1,0 +1,32 @@
+function installStorageFallback() {
+  if (window.localStorage) return;
+
+  const values = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(values.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    setItem(key: string, value: string) {
+      values.set(key, String(value));
+    },
+  };
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+}
+
+installStorageFallback();

--- a/react_frontend/vite.config.mts
+++ b/react_frontend/vite.config.mts
@@ -40,5 +40,6 @@ export default defineConfig({
     environment: "jsdom",
     exclude: ["e2e/**", "node_modules/**", "build/**", "dist/**"],
     globals: true,
+    setupFiles: ["src/__tests__/setup.ts"],
   },
 });

--- a/rust_admin/src/antd_client.rs
+++ b/rust_admin/src/antd_client.rs
@@ -85,6 +85,7 @@ impl AntdRestClient {
         Ok(Self {
             base_url: base_url.trim_end_matches('/').to_string(),
             client: reqwest::Client::builder()
+                .no_proxy()
                 .connect_timeout(Duration::from_secs(5))
                 .timeout(duration_from_secs_f64(timeout_seconds))
                 .build()?,

--- a/rust_stream/src/antd_client.rs
+++ b/rust_stream/src/antd_client.rs
@@ -33,6 +33,7 @@ impl AntdRestClient {
         Ok(Self {
             base_url: base_url.trim_end_matches('/').to_string(),
             client: reqwest::Client::builder()
+                .no_proxy()
                 .connect_timeout(Duration::from_secs(5))
                 .timeout(Duration::from_secs(60))
                 .build()?,


### PR DESCRIPTION
## Summary
- bypass proxy env for internal rust_admin/rust_stream calls to the local antd gateway
- make local frontend and app proxy healthchecks ignore injected proxy env for loopback probes
- add a Vitest setup fallback for Node environments where jsdom localStorage is unavailable

## Validation
- make compose-config
- SMOKE_BASE_URL=http://127.0.0.1 make smoke-local
- browser check: uploaded smoke video played and switched from 360P to 240p
- make devbench-exec ARGS='make test-rust'
- make devbench-exec ARGS='make fmt-rust'
- make devbench-exec ARGS='make clippy-rust'
- make test-react
- make devbench-exec ARGS='make test-react'
- make lint-react
- make build-react

## Notes
- Local Compose stack was left running for manual inspection at http://127.0.0.1.
- Devbench was stopped after validation.
- npm reported 3 moderate audit findings during install; dependency versions were not changed.