### PR TITLE
[codex] Fix HLS quality switch stalls

### DIFF
--- a/react_frontend/src/__tests__/playback.test.tsx
+++ b/react_frontend/src/__tests__/playback.test.tsx
@@ -218,8 +218,91 @@ test("passes the current playback position to hls.js when changing resolution", 
     hlsInstances[1].handlers[Hls.Events.MANIFEST_PARSED]();
   });
 
-  expect(video.currentTime).toBe(0);
+  expect(video.currentTime).toBe(42);
+  expect(hlsInstances[1].startLoad).toHaveBeenCalledTimes(1);
+
+  await act(async () => {
+    video.dispatchEvent(new Event("seeking"));
+    video.dispatchEvent(new Event("seeked"));
+  });
+
+  expect(hlsInstances[1].startLoad).toHaveBeenCalledTimes(1);
   expect(video.play).toHaveBeenCalled();
+});
+
+test("recovers hls.js network errors at the saved time after changing resolution", async () => {
+  Hls.isSupported.mockReturnValue(true);
+  const hlsInstances = [];
+  Hls.mockImplementation(function () {
+    const hlsInstance = {
+      attachMedia: vi.fn((media) => {
+        hlsInstance.media = media;
+      }),
+      destroy: vi.fn(() => {
+        if (hlsInstance.media) hlsInstance.media.currentTime = 0;
+      }),
+      handlers: {},
+      loadSource: vi.fn(),
+      media: null,
+      on: vi.fn((eventName, handler) => {
+        hlsInstance.handlers[eventName] = handler;
+      }),
+      recoverMediaError: vi.fn(),
+      startLoad: vi.fn(),
+    };
+    hlsInstances.push(hlsInstance);
+    return hlsInstance;
+  });
+  const publicVideo = {
+    created_at: "2026-04-27T12:00:00Z",
+    description: "Public description only",
+    id: "pub-resume-network",
+    original_filename: "",
+    status: "published",
+    title: "Network recovery stream",
+  };
+  setupGetRoutes({
+    publicVideos: [publicVideo],
+    details: {
+      "/api/videos/pub-resume-network": {
+        ...publicVideo,
+        manifest_address: null,
+        variants: [
+          { id: "variant-720", resolution: "720p", segment_count: 20 },
+          { id: "variant-480", resolution: "480p", segment_count: 20 },
+        ],
+      },
+    },
+  });
+
+  await renderApp();
+  await waitFor(() => expect(text()).toContain("Network recovery stream"));
+  await click(findButton("Network recovery stream"));
+
+  const video = container.querySelector("video");
+  Object.defineProperties(video, {
+    currentTime: { configurable: true, writable: true, value: 18 },
+    duration: { configurable: true, value: 40 },
+    ended: { configurable: true, value: false },
+    paused: { configurable: true, value: false },
+    play: { configurable: true, value: vi.fn(() => Promise.resolve()) },
+  });
+
+  await click(container.querySelector(".quality-toggle"));
+  await click(findButton("480p"));
+
+  expect(video.currentTime).toBe(0);
+
+  await act(async () => {
+    hlsInstances[1].handlers[Hls.Events.ERROR](Hls.Events.ERROR, {
+      fatal: true,
+      type: Hls.ErrorTypes.NETWORK_ERROR,
+    });
+  });
+
+  expect(hlsInstances[1].startLoad).toHaveBeenCalledWith(18);
+  expect(video.currentTime).toBe(18);
+  expect(text()).not.toContain("Playback failed because the video segments could not be loaded.");
 });
 
 test("honors a manual scrub to the beginning while hls.js reloads after a resolution change", async () => {

--- a/react_frontend/src/components/VideoPlayer.tsx
+++ b/react_frontend/src/components/VideoPlayer.tsx
@@ -114,12 +114,36 @@ export default function VideoPlayer({
     let restorePending = resumeAt > 0;
     let hlsManifestParsed = false;
     let resumedAfterRestore = false;
+    let suppressNextHlsSeekSync = false;
     let nativeSeekRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
     let nativeSeekResumeAt = 0;
     let nativeSeekShouldResume = false;
     const readCurrentTime = () => (
       Number.isFinite(video.currentTime) ? video.currentTime : 0
     );
+    const seekVideoTo = (targetTime: number) => {
+      if (targetTime <= 0) return;
+
+      const duration = video.duration;
+      if (
+        Number.isFinite(duration) &&
+        duration <= targetTime + RESUME_DURATION_TOLERANCE_SECONDS
+      ) {
+        return;
+      }
+
+      if (Math.abs(readCurrentTime() - targetTime) <= RESUME_DURATION_TOLERANCE_SECONDS) {
+        return;
+      }
+
+      try {
+        suppressNextHlsSeekSync = true;
+        video.currentTime = targetTime;
+      } catch {
+        suppressNextHlsSeekSync = false;
+        // MediaSource can briefly reject seeks while hls.js is rebuilding buffers.
+      }
+    };
     const clearNativeSeekRecoveryTimer = () => {
       if (nativeSeekRecoveryTimer) {
         clearTimeout(nativeSeekRecoveryTimer);
@@ -156,6 +180,10 @@ export default function VideoPlayer({
     };
     const syncPendingSeek = () => {
       if (!restorePending) return;
+      if (suppressNextHlsSeekSync) {
+        suppressNextHlsSeekSync = false;
+        return;
+      }
       pendingResumeAt = readCurrentTime();
       playbackStateRef.current = { currentTime: pendingResumeAt, shouldResume };
 
@@ -285,10 +313,31 @@ export default function VideoPlayer({
         video.addEventListener("canplay", finishRestore);
         video.addEventListener("playing", finishRestore);
         video.addEventListener("seeking", syncPendingSeek);
+        const hlsLoadPosition = () => {
+          const currentTime = readCurrentTime();
+          if (
+            restorePending &&
+            pendingResumeAt > RESUME_DURATION_TOLERANCE_SECONDS &&
+            currentTime <= RESUME_DURATION_TOLERANCE_SECONDS
+          ) {
+            return pendingResumeAt;
+          }
+          return currentTime > 0 ? currentTime : 0;
+        };
+        const recoverHlsPlayback = () => {
+          if (!active || video.ended || video.paused || !wantsPlayback()) return;
+          const loadPosition = hlsLoadPosition();
+          hls.startLoad(loadPosition);
+          seekVideoTo(loadPosition);
+        };
+        video.addEventListener("stalled", recoverHlsPlayback);
+        video.addEventListener("waiting", recoverHlsPlayback);
         hls.on(Hls.Events.MANIFEST_PARSED, () => {
           hlsManifestParsed = true;
           if (restorePending) {
-            hls.startLoad(pendingResumeAt > 0 ? pendingResumeAt : 0);
+            const loadPosition = hlsLoadPosition();
+            hls.startLoad(loadPosition);
+            seekVideoTo(loadPosition);
           }
           resumePlayback();
         });
@@ -299,7 +348,9 @@ export default function VideoPlayer({
               && networkRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
             ) {
               networkRecoveryAttempts += 1;
-              hls.startLoad();
+              const loadPosition = hlsLoadPosition();
+              hls.startLoad(loadPosition);
+              seekVideoTo(loadPosition);
               return;
             }
 
@@ -308,6 +359,7 @@ export default function VideoPlayer({
               && mediaRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
             ) {
               mediaRecoveryAttempts += 1;
+              seekVideoTo(hlsLoadPosition());
               hls.recoverMediaError();
               return;
             }
@@ -319,6 +371,8 @@ export default function VideoPlayer({
           video.removeEventListener("canplay", finishRestore);
           video.removeEventListener("playing", finishRestore);
           video.removeEventListener("seeking", syncPendingSeek);
+          video.removeEventListener("stalled", recoverHlsPlayback);
+          video.removeEventListener("waiting", recoverHlsPlayback);
           hls.destroy();
           hlsRef.current = null;
         };

--- a/rust_admin/src/media.rs
+++ b/rust_admin/src/media.rs
@@ -1,4 +1,5 @@
 use std::{
+    ffi::OsString,
     fs, io,
     path::{Path as FsPath, PathBuf},
     sync::Arc,
@@ -237,64 +238,18 @@ async fn run_ffmpeg(
     let seg_dir = assert_under(seg_dir, &state.config.upload_temp_dir)?;
     let segment_pattern =
         assert_under(&seg_dir.join("seg_%05d.ts"), &state.config.upload_temp_dir)?;
-    let segment_time = format!("{}", F64Format(state.config.hls_segment_duration));
     let mut command = Command::new("ffmpeg");
-    command
-        .arg("-hide_banner")
-        .arg("-nostats")
-        .arg("-loglevel")
-        .arg("warning")
-        .arg("-y")
-        .arg("-filter_threads")
-        .arg(state.config.ffmpeg_filter_threads.to_string())
-        .arg("-i")
-        .arg(&src)
-        .arg("-map")
-        .arg("0:v:0")
-        .arg("-map")
-        .arg("0:a?")
-        .arg("-sn")
-        .arg("-c:v")
-        .arg("libx264")
-        .arg("-threads")
-        .arg(state.config.ffmpeg_threads.to_string())
-        .arg("-preset")
-        .arg("veryfast")
-        .arg("-profile:v")
-        .arg("high")
-        .arg("-pix_fmt")
-        .arg("yuv420p")
-        .arg("-vf")
-        .arg(format!(
-            "scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2"
-        ))
-        .arg("-b:v")
-        .arg(format!("{video_kbps}k"))
-        .arg("-maxrate")
-        .arg(format!("{}k", video_kbps * 3 / 2))
-        .arg("-bufsize")
-        .arg(format!("{}k", video_kbps * 2))
-        .arg("-force_key_frames")
-        .arg(format!("expr:gte(t,n_forced*{segment_time})"))
-        .arg("-sc_threshold")
-        .arg("0")
-        .arg("-c:a")
-        .arg("aac")
-        .arg("-b:a")
-        .arg(format!("{audio_kbps}k"))
-        .arg("-ar")
-        .arg("44100")
-        .arg("-f")
-        .arg("segment")
-        .arg("-segment_time")
-        .arg(segment_time)
-        .arg("-segment_time_delta")
-        .arg("0.05")
-        .arg("-segment_format")
-        .arg("mpegts")
-        .arg("-reset_timestamps")
-        .arg("1")
-        .arg(segment_pattern);
+    command.args(ffmpeg_transcode_args(FfmpegTranscodeOptions {
+        src: &src,
+        segment_pattern: &segment_pattern,
+        filter_threads: state.config.ffmpeg_filter_threads,
+        ffmpeg_threads: state.config.ffmpeg_threads,
+        hls_segment_duration: state.config.hls_segment_duration,
+        width,
+        height,
+        video_kbps,
+        audio_kbps,
+    }));
     let output =
         run_command_output(command, Some(state.config.ffmpeg_rendition_timeout_seconds)).await?;
     if output.status_code != Some(0) {
@@ -314,6 +269,89 @@ async fn run_ffmpeg(
         ));
     }
     Ok(())
+}
+
+struct FfmpegTranscodeOptions<'a> {
+    src: &'a FsPath,
+    segment_pattern: &'a FsPath,
+    filter_threads: usize,
+    ffmpeg_threads: usize,
+    hls_segment_duration: f64,
+    width: i32,
+    height: i32,
+    video_kbps: i32,
+    audio_kbps: i32,
+}
+
+fn ffmpeg_transcode_args(options: FfmpegTranscodeOptions<'_>) -> Vec<OsString> {
+    let segment_time = format!("{}", F64Format(options.hls_segment_duration));
+    [
+        "-hide_banner",
+        "-nostats",
+        "-loglevel",
+        "warning",
+        "-y",
+        "-filter_threads",
+        &options.filter_threads.to_string(),
+        "-i",
+    ]
+    .into_iter()
+    .map(OsString::from)
+    .chain([options.src.as_os_str().to_owned()])
+    .chain(
+        [
+            "-map",
+            "0:v:0",
+            "-map",
+            "0:a?",
+            "-sn",
+            "-c:v",
+            "libx264",
+            "-threads",
+            &options.ffmpeg_threads.to_string(),
+            "-preset",
+            "veryfast",
+            "-profile:v",
+            "high",
+            "-pix_fmt",
+            "yuv420p",
+            "-vf",
+            &format!(
+                "scale={}:{}:force_original_aspect_ratio=decrease,pad={}:{}:(ow-iw)/2:(oh-ih)/2",
+                options.width, options.height, options.width, options.height
+            ),
+            "-b:v",
+            &format!("{}k", options.video_kbps),
+            "-maxrate",
+            &format!("{}k", options.video_kbps * 3 / 2),
+            "-bufsize",
+            &format!("{}k", options.video_kbps * 2),
+            "-force_key_frames",
+            &format!("expr:gte(t,n_forced*{segment_time})"),
+            "-sc_threshold",
+            "0",
+            "-c:a",
+            "aac",
+            "-b:a",
+            &format!("{}k", options.audio_kbps),
+            "-ar",
+            "44100",
+            "-f",
+            "segment",
+            "-segment_time",
+            &segment_time,
+            "-segment_time_delta",
+            "0.05",
+            "-segment_format",
+            "mpegts",
+            "-reset_timestamps",
+            "0",
+        ]
+        .into_iter()
+        .map(OsString::from),
+    )
+    .chain([options.segment_pattern.as_os_str().to_owned()])
+    .collect()
 }
 
 struct F64Format(f64);
@@ -765,14 +803,16 @@ pub(crate) fn enforce_upload_media_limits(
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::Path;
 
     use axum::http::StatusCode;
     use serde_json::json;
     use uuid::Uuid;
 
     use super::{
-        assert_under, collect_segment_files, estimate_transcoded_bytes, parse_probe_duration,
-        stream_rotation_degrees, target_dimensions_for_source, target_video_bitrate_kbps,
+        assert_under, collect_segment_files, estimate_transcoded_bytes, ffmpeg_transcode_args,
+        parse_probe_duration, stream_rotation_degrees, target_dimensions_for_source,
+        target_video_bitrate_kbps, FfmpegTranscodeOptions,
     };
 
     #[test]
@@ -858,6 +898,33 @@ mod tests {
 
         assert_eq!(names, vec!["seg_00002.ts", "seg_00010.ts", "seg_bad.ts"]);
         let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn ffmpeg_segments_keep_continuous_timestamps_for_hls_seeks() {
+        let args = ffmpeg_transcode_args(FfmpegTranscodeOptions {
+            src: Path::new("/tmp/source.mp4"),
+            segment_pattern: Path::new("/tmp/seg_%05d.ts"),
+            filter_threads: 1,
+            ffmpeg_threads: 2,
+            hls_segment_duration: 1.0,
+            width: 640,
+            height: 360,
+            video_kbps: 500,
+            audio_kbps: 96,
+        })
+        .into_iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+        let reset_timestamp_index = args
+            .iter()
+            .position(|arg| arg == "-reset_timestamps")
+            .expect("reset timestamp flag should be explicit");
+
+        assert_eq!(
+            args.get(reset_timestamp_index + 1).map(String::as_str),
+            Some("0")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes HLS playback stalls after switching quality by keeping hls.js recovery anchored to the intended playback time.
- Changes new FFmpeg segment generation to preserve continuous MPEG-TS timestamps so HLS seeks and rendition switches map to the correct timeline.
- Adds regression coverage for quality-switch resume and hls.js network recovery at the saved time.

## Root Cause
The frontend could restart hls.js loading from an imprecise position during quality-switch recovery, and newly transcoded MPEG-TS segments reset timestamps per segment. That combination made mid-video quality switches and subsequent seeks fragile, especially on local testnet segment fetches.

## Validation
- `make test-react`
- `make lint-react`
- `make build-react` (passes with existing large HLS chunk warning)
- `make devbench-exec ARGS='make fmt-rust'`
- `make devbench-exec ARGS='make test-rust-admin'`
- `make devbench-exec ARGS='make clippy-rust-admin'`
- `git diff --check`

## Claude Review
- Initial Claude Ultrareview verified two frontend recovery issues.
- Both issues were fixed and the commit was amended.
- Final Claude Ultrareview completed with no findings.
