### PR TITLE
[codex] Fix desktop startup wallet and ACL handling

### DIFF
--- a/antd_service/src/client.rs
+++ b/antd_service/src/client.rs
@@ -73,10 +73,18 @@ pub(crate) async fn connect_client() -> anyhow::Result<CoreClient> {
     };
 
     if !private_key.starts_with("0x") {
-        private_key = format!("0x{private_key}");
+        let mut unprefixed_private_key = std::mem::take(&mut private_key);
+        private_key = format!("0x{unprefixed_private_key}");
+        unprefixed_private_key.zeroize();
     }
 
-    let wallet = evmlib::wallet::Wallet::new_from_private_key(evm_network, &private_key)?;
+    let wallet = match evmlib::wallet::Wallet::new_from_private_key(evm_network, &private_key) {
+        Ok(wallet) => wallet,
+        Err(err) => {
+            private_key.zeroize();
+            return Err(err.into());
+        }
+    };
     private_key.zeroize();
 
     Ok(client.with_wallet(wallet))
@@ -84,14 +92,26 @@ pub(crate) async fn connect_client() -> anyhow::Result<CoreClient> {
 
 fn wallet_key() -> Option<String> {
     non_empty_env("AUTONOMI_WALLET_KEY_FILE")
-        .and_then(|path| match fs::read_to_string(&path) {
-            Ok(value) => Some(value),
-            Err(err) => {
-                warn!("Could not read AUTONOMI_WALLET_KEY_FILE at {path}: {err}");
-                None
-            }
-        })
+        .and_then(|path| read_wallet_key_file(&path))
         .or_else(|| non_empty_env("AUTONOMI_WALLET_KEY"))
+}
+
+fn read_wallet_key_file(path: &str) -> Option<String> {
+    match fs::read_to_string(path) {
+        Ok(mut value) => {
+            let key = value.trim().to_string();
+            value.zeroize();
+            if key.is_empty() {
+                None
+            } else {
+                Some(key)
+            }
+        }
+        Err(err) => {
+            warn!("Could not read AUTONOMI_WALLET_KEY_FILE at {path}: {err}");
+            None
+        }
+    }
 }
 
 fn evm_network() -> evmlib::Network {
@@ -206,6 +226,27 @@ async fn start_node_with_warmup(node: Arc<P2PNode>) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    use super::read_wallet_key_file;
+
+    #[test]
+    fn wallet_key_file_trims_secret_file_newline() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(
+            file,
+            "  0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  "
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_wallet_key_file(file.path().to_str().unwrap()).as_deref(),
+            Some("0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/desktop_app/src-tauri/Cargo.lock
+++ b/desktop_app/src-tauri/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-opener",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/desktop_app/src-tauri/Cargo.toml
+++ b/desktop_app/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1", features = ["derive"] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tokio = { version = "1", features = ["sync"] }
+url = "2"
 
 [features]
 custom-protocol = ["tauri/custom-protocol"]

--- a/desktop_app/src-tauri/build.rs
+++ b/desktop_app/src-tauri/build.rs
@@ -1,3 +1,11 @@
 fn main() {
-    tauri_build::build();
+    tauri_build::try_build(tauri_build::Attributes::new().app_manifest(
+        tauri_build::AppManifest::new().commands(&[
+            "desktop_setup_status",
+            "desktop_save_setup",
+            "desktop_start_stack",
+            "desktop_open_in_browser",
+        ]),
+    ))
+    .expect("failed to build Tauri app manifest");
 }

--- a/desktop_app/src-tauri/capabilities/default.json
+++ b/desktop_app/src-tauri/capabilities/default.json
@@ -5,6 +5,10 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "allow-desktop-setup-status",
+    "allow-desktop-save-setup",
+    "allow-desktop-start-stack",
+    "allow-desktop-open-in-browser"
   ]
 }

--- a/desktop_app/src-tauri/permissions/autogenerated/desktop_open_in_browser.toml
+++ b/desktop_app/src-tauri/permissions/autogenerated/desktop_open_in_browser.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-desktop-open-in-browser"
+description = "Enables the desktop_open_in_browser command without any pre-configured scope."
+commands.allow = ["desktop_open_in_browser"]
+
+[[permission]]
+identifier = "deny-desktop-open-in-browser"
+description = "Denies the desktop_open_in_browser command without any pre-configured scope."
+commands.deny = ["desktop_open_in_browser"]

--- a/desktop_app/src-tauri/permissions/autogenerated/desktop_save_setup.toml
+++ b/desktop_app/src-tauri/permissions/autogenerated/desktop_save_setup.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-desktop-save-setup"
+description = "Enables the desktop_save_setup command without any pre-configured scope."
+commands.allow = ["desktop_save_setup"]
+
+[[permission]]
+identifier = "deny-desktop-save-setup"
+description = "Denies the desktop_save_setup command without any pre-configured scope."
+commands.deny = ["desktop_save_setup"]

--- a/desktop_app/src-tauri/permissions/autogenerated/desktop_setup_status.toml
+++ b/desktop_app/src-tauri/permissions/autogenerated/desktop_setup_status.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-desktop-setup-status"
+description = "Enables the desktop_setup_status command without any pre-configured scope."
+commands.allow = ["desktop_setup_status"]
+
+[[permission]]
+identifier = "deny-desktop-setup-status"
+description = "Denies the desktop_setup_status command without any pre-configured scope."
+commands.deny = ["desktop_setup_status"]

--- a/desktop_app/src-tauri/permissions/autogenerated/desktop_start_stack.toml
+++ b/desktop_app/src-tauri/permissions/autogenerated/desktop_start_stack.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-desktop-start-stack"
+description = "Enables the desktop_start_stack command without any pre-configured scope."
+commands.allow = ["desktop_start_stack"]
+
+[[permission]]
+identifier = "deny-desktop-start-stack"
+description = "Denies the desktop_start_stack command without any pre-configured scope."
+commands.deny = ["desktop_start_stack"]

--- a/desktop_app/src-tauri/src/main.rs
+++ b/desktop_app/src-tauri/src/main.rs
@@ -130,7 +130,26 @@ fn resolve_binary_dir<R: Runtime>(app: &tauri::AppHandle<R>) -> Option<PathBuf> 
 
 #[tauri::command]
 async fn desktop_open_in_browser(url: String) -> Result<(), String> {
+    validate_launcher_url(&url)?;
     tauri_plugin_opener::open_url(url, None::<&str>).map_err(|err| err.to_string())
+}
+
+fn validate_launcher_url(value: &str) -> Result<(), String> {
+    let parsed = url::Url::parse(value).map_err(|_| "launcher URL is invalid".to_string())?;
+    let is_loopback_host = matches!(
+        parsed.host_str(),
+        Some("127.0.0.1" | "localhost" | "::1" | "[::1]")
+    );
+    if parsed.scheme() == "http"
+        && is_loopback_host
+        && parsed.port().is_some()
+        && parsed.username().is_empty()
+        && parsed.password().is_none()
+    {
+        Ok(())
+    } else {
+        Err("launcher URL must be a loopback HTTP URL".to_string())
+    }
 }
 
 fn main() {
@@ -174,4 +193,24 @@ fn main() {
         })
         .run(tauri::generate_context!())
         .expect("error while running Autonomi Video Management");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_launcher_url;
+
+    #[test]
+    fn validates_loopback_launcher_urls() {
+        assert!(validate_launcher_url("http://127.0.0.1:8080").is_ok());
+        assert!(validate_launcher_url("http://localhost:49152").is_ok());
+        assert!(validate_launcher_url("http://[::1]:8080").is_ok());
+    }
+
+    #[test]
+    fn rejects_non_launcher_urls() {
+        assert!(validate_launcher_url("https://127.0.0.1:8080").is_err());
+        assert!(validate_launcher_url("http://example.com:8080").is_err());
+        assert!(validate_launcher_url("http://127.0.0.1").is_err());
+        assert!(validate_launcher_url("http://user@127.0.0.1:8080").is_err());
+    }
 }

--- a/react_frontend/src/desktop.test.ts
+++ b/react_frontend/src/desktop.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+
+import { isLaunchedLocalAppLocation } from "./desktop";
+
+describe("isLaunchedLocalAppLocation", () => {
+  test("detects the launcher-served desktop app on loopback HTTP", () => {
+    expect(isLaunchedLocalAppLocation({
+      hostname: "127.0.0.1",
+      port: "8080",
+      protocol: "http:",
+    })).toBe(true);
+    expect(isLaunchedLocalAppLocation({
+      hostname: "localhost",
+      port: "49152",
+      protocol: "http:",
+    })).toBe(true);
+  });
+
+  test("keeps Tauri dev server URLs eligible for setup IPC", () => {
+    expect(isLaunchedLocalAppLocation({
+      hostname: "127.0.0.1",
+      port: "5173",
+      protocol: "http:",
+    })).toBe(false);
+  });
+
+  test("does not treat Tauri asset origins as launched local app URLs", () => {
+    expect(isLaunchedLocalAppLocation({
+      hostname: "tauri.localhost",
+      port: "",
+      protocol: "http:",
+    })).toBe(false);
+    expect(isLaunchedLocalAppLocation({
+      hostname: "localhost",
+      port: "",
+      protocol: "tauri:",
+    })).toBe(false);
+  });
+
+  test("does not treat external browser URLs as launched local app URLs", () => {
+    expect(isLaunchedLocalAppLocation({
+      hostname: "example.com",
+      port: "",
+      protocol: "https:",
+    })).toBe(false);
+  });
+});

--- a/react_frontend/src/desktop.ts
+++ b/react_frontend/src/desktop.ts
@@ -16,7 +16,23 @@ type TauriCore = {
 };
 
 export function isDesktopRuntime(): boolean {
-  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+  if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) {
+    return false;
+  }
+
+  const { hostname, port, protocol } = window.location;
+  const isLaunchedLocalApp = isLaunchedLocalAppLocation({ hostname, port, protocol });
+
+  return !isLaunchedLocalApp;
+}
+
+export function isLaunchedLocalAppLocation(location: Pick<Location, "hostname" | "port" | "protocol">): boolean {
+  const { hostname, port, protocol } = location;
+  const isLocalHttp = protocol === "http:" || protocol === "https:";
+  const isLoopbackHost = hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]";
+
+  // Tauri dev loads Vite on 5173 and still needs setup IPC; the launched app UI does not.
+  return isLocalHttp && isLoopbackHost && port !== "5173";
 }
 
 async function tauriCore(): Promise<TauriCore> {


### PR DESCRIPTION
## Summary

- Trim file-backed `antd` wallet keys before EVM private-key parsing so newline-terminated secret files work, including zeroizing key copies on parse errors.
- Declare the desktop Tauri commands in the app manifest and grant the generated command permissions to the main window capability.
- Stop the React desktop setup gate from invoking Tauri setup IPC after the shell has redirected into the local launcher URL.
- Restrict `desktop_open_in_browser` to loopback HTTP launcher URLs.
- Add coverage for launcher/dev/asset/external URL desktop-runtime detection and launcher URL validation.

## Root Cause

Desktop first-run setup writes secret files with a trailing newline. `antd` read `AUTONOMI_WALLET_KEY_FILE` verbatim, so an otherwise valid 64-character hex key could fail with `Private key is invalid`. A rebuilt Tauri app also exposed missing ACL wiring for custom desktop commands, and the redirected localhost frontend could try privileged setup IPC from the launched app origin.

## Validation

- `make fmt-rust`
- `cargo test -p antd`
- `cd desktop_app/src-tauri && cargo fmt --check && cargo test`
- `cd react_frontend && npm run test -- desktop.test.ts`
- `make build-react`
- `AUTVID_ALLOW_DYNAMIC_FFMPEG=1 FFMPEG_BIN="$PWD/desktop_app/src-tauri/target/release/ffmpeg" FFPROBE_BIN="$PWD/desktop_app/src-tauri/target/release/ffprobe" make build-tauri`
- Installed the rebuilt app to `/Applications/Autonomi Video Management.app` and `~/Applications/Autonomi Video Management.app`
- Launched the installed app and verified:
  - `http://127.0.0.1:8080/api/livez`
  - `http://127.0.0.1:8080/stream/livez`
  - `http://127.0.0.1:8082/livez`

Note: the local desktop rebuild used `AUTVID_ALLOW_DYNAMIC_FFMPEG=1` with the previously staged local FFmpeg/FFprobe tools. This is suitable for this local reinstall, not a public notarized release artifact.
