### PR TITLE
[codex] Fix desktop login refresh cookie

### DIFF
--- a/docs/DESKTOP_APP.md
+++ b/docs/DESKTOP_APP.md
@@ -16,7 +16,10 @@ The desktop app keeps the existing service boundaries:
 On first run, the Tauri shell requires admin credentials and an Autonomi wallet
 key or key-file path. The launcher writes file-backed secrets into the app data
 directory with private file permissions and starts services with
-`AUTVID_STRICT_AUTH=true`, `APP_ENV=production`, and file-backed admin secrets.
+`AUTVID_STRICT_AUTH=true`, `APP_ENV=production`, `ADMIN_AUTH_COOKIE_SECURE=false`,
+and file-backed admin secrets. Desktop uses non-Secure auth cookies because the
+installed app talks to the local launcher over loopback HTTP; hosted HTTPS
+deployments should keep Secure cookies enabled.
 If the wallet key is pasted into first-run setup, it is stored in the app data
 directory under `secrets/autonomi-wallet-key` with private file permissions. If
 you select an existing wallet key file instead, the app stores only that file

--- a/launcher_core/src/lib.rs
+++ b/launcher_core/src/lib.rs
@@ -488,13 +488,12 @@ fn start_rust_admin(
         .env("TEMP", processing_dir)
         .env("ANTD_URL", antd_url)
         .env("RUST_ADMIN_PORT", admin_port.to_string())
-        .env("CORS_ALLOWED_ORIGINS", launcher_url)
-        .env("APP_ENV", "production")
-        // The desktop launcher serves the production-built app over loopback HTTP.
-        // Keep strict auth enabled, but do not mark cookies Secure unless the
-        // browser is actually talking to the admin service over HTTPS.
-        .env("ADMIN_AUTH_COOKIE_SECURE", "false")
-        .env("AUTVID_STRICT_AUTH", "true")
+        .env("CORS_ALLOWED_ORIGINS", launcher_url);
+    // The desktop launcher serves the production-built app over loopback HTTP.
+    // Keep strict auth enabled, but do not mark cookies Secure unless the
+    // browser is actually talking to the admin service over HTTPS.
+    apply_desktop_admin_auth_env(&mut command);
+    command
         .env(
             "ADMIN_DB_MIN_CONNECTIONS",
             env::var("ADMIN_DB_MIN_CONNECTIONS").unwrap_or_else(|_| "1".into()),
@@ -516,6 +515,20 @@ fn start_rust_admin(
         command.env("FFPROBE_BIN", ffprobe);
     }
     spawn("rust_admin", command, logs_dir, run_dir)
+}
+
+fn desktop_admin_auth_env() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("APP_ENV", "production"),
+        ("ADMIN_AUTH_COOKIE_SECURE", "false"),
+        ("AUTVID_STRICT_AUTH", "true"),
+    ]
+}
+
+fn apply_desktop_admin_auth_env(command: &mut Command) {
+    for (key, value) in desktop_admin_auth_env() {
+        command.env(key, value);
+    }
 }
 
 fn start_rust_stream(
@@ -1086,6 +1099,22 @@ mod tests {
         env::set_var("AUTVID_TEST_PORT", "45678");
         assert_eq!(env_port_or_available("AUTVID_TEST_PORT", 1).unwrap(), 45678);
         env::remove_var("AUTVID_TEST_PORT");
+    }
+
+    #[test]
+    fn desktop_admin_auth_env_is_applied_to_admin_command() {
+        let mut command = Command::new("rust_admin");
+        apply_desktop_admin_auth_env(&mut command);
+
+        for (expected_key, expected_value) in desktop_admin_auth_env() {
+            let value = command
+                .as_std()
+                .get_envs()
+                .find(|(key, _)| *key == std::ffi::OsStr::new(expected_key))
+                .and_then(|(_, value)| value)
+                .map(|value| value.to_string_lossy().into_owned());
+            assert_eq!(value.as_deref(), Some(*expected_value));
+        }
     }
 
     #[cfg(unix)]

--- a/launcher_core/src/lib.rs
+++ b/launcher_core/src/lib.rs
@@ -490,6 +490,10 @@ fn start_rust_admin(
         .env("RUST_ADMIN_PORT", admin_port.to_string())
         .env("CORS_ALLOWED_ORIGINS", launcher_url)
         .env("APP_ENV", "production")
+        // The desktop launcher serves the production-built app over loopback HTTP.
+        // Keep strict auth enabled, but do not mark cookies Secure unless the
+        // browser is actually talking to the admin service over HTTPS.
+        .env("ADMIN_AUTH_COOKIE_SECURE", "false")
         .env("AUTVID_STRICT_AUTH", "true")
         .env(
             "ADMIN_DB_MIN_CONNECTIONS",


### PR DESCRIPTION
## Summary

Fixes desktop login sessions by explicitly disabling the `Secure` cookie attribute for the installed desktop launcher, which serves the production-built app over loopback HTTP.

## Root Cause

The desktop launcher starts `rust_admin` with `APP_ENV=production`, which makes auth cookies default to `Secure`. Because the installed app talks to the local launcher at `http://127.0.0.1:8080`, browsers do not send those cookies back. Login can appear to succeed, but the follow-up `/auth/me` request is unauthenticated and the frontend falls into `/auth/refresh`, producing `Refresh token required`.

## Changes

- Set `ADMIN_AUTH_COOKIE_SECURE=false` only for the desktop-launched `rust_admin` process.
- Keep `APP_ENV=production` and `AUTVID_STRICT_AUTH=true` for the desktop app.
- Document why desktop loopback HTTP uses non-Secure cookies while hosted HTTPS deployments should keep Secure cookies enabled.

## Validation

- `make fmt-rust`
- `cargo test -p launcher_core`
- `AUTVID_ALLOW_DYNAMIC_FFMPEG=1 FFMPEG_BIN="$PWD/desktop_app/src-tauri/target/release/ffmpeg" FFPROBE_BIN="$PWD/desktop_app/src-tauri/target/release/ffprobe" make build-tauri`
- Reinstalled the built macOS app into `/Applications` and `~/Applications`
- User confirmed the newly installed app now allows login successfully


## Review Follow-up

- Claude Code Opus 4.8 reviewed the PR and found no blocking issues.
- Addressed Claude's test-gap suggestion by adding a launcher unit test that verifies the desktop auth env is applied to the spawned admin command.
