### PR TITLE
[codex] Fix desktop stream proxy route

### DIFF
--- a/launcher_core/src/lib.rs
+++ b/launcher_core/src/lib.rs
@@ -957,7 +957,11 @@ async fn proxy_stream(
     headers: HeaderMap,
     request: Request<Body>,
 ) -> Response<Body> {
-    proxy_to(state, headers, request, format!("/{}", path), false).await
+    proxy_to(state, headers, request, stream_proxy_path(&path), false).await
+}
+
+fn stream_proxy_path(path: &str) -> String {
+    format!("/stream/{path}")
 }
 
 async fn proxy_to(
@@ -1115,6 +1119,14 @@ mod tests {
                 .map(|value| value.to_string_lossy().into_owned());
             assert_eq!(value.as_deref(), Some(*expected_value));
         }
+    }
+
+    #[test]
+    fn stream_proxy_preserves_stream_prefix_for_sidecar_routes() {
+        assert_eq!(
+            stream_proxy_path("manifest/address/720p/playlist.m3u8"),
+            "/stream/manifest/address/720p/playlist.m3u8"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Fixes desktop playback for uploaded Autonomi videos by preserving the `/stream` prefix when the Tauri launcher proxies stream requests to the `rust_stream` sidecar.

## Root Cause

The packaged desktop frontend receives `streamBaseUrl: '/stream'` and builds URLs like `/stream/manifest/{address}/{resolution}/playlist.m3u8`. The launcher matched `/stream/{*path}` but forwarded only `/{path}` to the sidecar. The sidecar routes are mounted under `/stream/...`, so manifest and segment requests returned 404 through the packaged app even though direct sidecar playback worked.

## Impact

Admin playback by manifest address should now reach the stream sidecar correctly. Public catalog state is unchanged.

## Validation

- `make fmt-rust`
- `cargo test -p launcher_core`
- `make test-rust`
- `make clippy-rust`
