### PR TITLE
[codex] Document desktop stream proxy route

### DIFF
--- a/launcher_core/src/lib.rs
+++ b/launcher_core/src/lib.rs
@@ -961,6 +961,7 @@ async fn proxy_stream(
 }
 
 fn stream_proxy_path(path: &str) -> String {
+    // rust_stream mounts playback routes under /stream; preserve the prefix Axum strips here.
     format!("/stream/{path}")
 }
 


### PR DESCRIPTION
## Summary
- documents why the desktop launcher preserves the /stream prefix when proxying playback routes

## Verification
- make fmt-rust