### PR TITLE
[codex] Add configurable upload encoder settings

### DIFF
--- a/react_frontend/src/__tests__/upload.test.tsx
+++ b/react_frontend/src/__tests__/upload.test.tsx
@@ -45,6 +45,19 @@ test("shows an upload quote after local video metadata is available", async () =
     if (url === "/videos/upload/quote") {
       expect(body).toEqual({
         duration_seconds: 64,
+        encode_settings: {
+          audio_bitrate_kbps: 320,
+          video_bitrate_overrides: {
+            "1080p": 12000,
+            "720p": 7500,
+            "540p": 4500,
+            "480p": 3000,
+            "360p": 1500,
+            "240p": 800,
+            "144p": 350,
+          },
+          video_codec: "h264",
+        },
         resolutions: ["1080p", "720p", "540p", "480p", "360p", "240p", "144p"],
         source_height: 1080,
         source_width: 1920,
@@ -173,6 +186,16 @@ test("sends original-source and auto-publish options with an upload", async () =
   expect(uploadedForm.get("upload_original")).toBe("true");
   expect(uploadedForm.get("publish_when_ready")).toBe("true");
   expect(uploadedForm.get("show_manifest_address")).toBe("false");
+  expect(uploadedForm.get("video_codec")).toBe("h264");
+  expect(uploadedForm.get("audio_bitrate_kbps")).toBe("320");
+  expect(JSON.parse(uploadedForm.get("video_bitrate_overrides"))).toEqual({
+    "720p": 7500,
+    "540p": 4500,
+    "480p": 3000,
+    "360p": 1500,
+    "240p": 800,
+    "144p": 350,
+  });
   expect(uploadedForm.get("file")).toBe(file);
 });
 

--- a/react_frontend/src/components/UploadPanel.tsx
+++ b/react_frontend/src/components/UploadPanel.tsx
@@ -9,7 +9,13 @@ import {
 
 import { isRequestCanceled, requestErrorMessage, requestUploadQuote, uploadVideo } from "../api/client";
 import { RESOLUTION_OPTIONS } from "../constants";
-import type { SourceVideoMeta, UploadQuote, UploadQuoteRequest, VideoSummary } from "../types";
+import type {
+  EncodeSettings,
+  SourceVideoMeta,
+  UploadQuote,
+  UploadQuoteRequest,
+  VideoSummary,
+} from "../types";
 import { formatAttoTokens, formatBytes, formatWei } from "../utils/format";
 import {
   classifyResolution,
@@ -30,6 +36,43 @@ interface UploadPanelProps {
   onUploaded: (video: VideoSummary) => void;
 }
 
+type VideoCodec = EncodeSettings["video_codec"];
+
+const DEFAULT_AUDIO_BITRATE_KBPS = 320;
+
+function defaultVideoBitrate(optionKbps: number, codec: VideoCodec): number {
+  if (codec === "hevc") return Math.max(64, Math.round((optionKbps * 0.7) / 50) * 50);
+  return optionKbps;
+}
+
+function defaultVideoBitrates(codec: VideoCodec): Record<string, number> {
+  return Object.fromEntries(
+    RESOLUTION_OPTIONS.map((option) => [
+      option.value,
+      defaultVideoBitrate(option.defaultVideoBitrateKbps, codec),
+    ]),
+  );
+}
+
+function buildEncodeSettings(
+  resolutions: string[],
+  videoCodec: VideoCodec,
+  videoBitrates: Record<string, number>,
+  audioBitrateKbps: number,
+): EncodeSettings {
+  const video_bitrate_overrides = Object.fromEntries(
+    resolutions.map((resolution) => [
+      resolution,
+      Math.max(64, Math.round(videoBitrates[resolution] || 0)),
+    ]),
+  );
+  return {
+    video_codec: videoCodec,
+    audio_bitrate_kbps: Math.max(32, Math.round(audioBitrateKbps || DEFAULT_AUDIO_BITRATE_KBPS)),
+    video_bitrate_overrides,
+  };
+}
+
 export default function UploadPanel({ onUploaded }: UploadPanelProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [file, setFile] = useState<File | null>(null);
@@ -39,6 +82,11 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
   const [uploadOriginal, setUploadOriginal] = useState(false);
   const [publishWhenReady, setPublishWhenReady] = useState(false);
   const [selected, setSelected] = useState<string[]>(["720p"]);
+  const [videoCodec, setVideoCodec] = useState<VideoCodec>("h264");
+  const [audioBitrateKbps, setAudioBitrateKbps] = useState(DEFAULT_AUDIO_BITRATE_KBPS);
+  const [videoBitrates, setVideoBitrates] = useState<Record<string, number>>(
+    () => defaultVideoBitrates("h264"),
+  );
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState("");
   const [progress, setProgress] = useState(0);
@@ -96,8 +144,15 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
       const resolutions = orderedSelection(selected);
       setQuote({ loading: true, error: "", data: null });
       try {
+        const encodeSettings = buildEncodeSettings(
+          resolutions,
+          videoCodec,
+          videoBitrates,
+          audioBitrateKbps,
+        );
         const quoteRequest: UploadQuoteRequest = {
           duration_seconds: duration,
+          encode_settings: encodeSettings,
           resolutions,
           source_width: meta.width,
           source_height: meta.height,
@@ -122,7 +177,17 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
       controller.abort();
       clearTimeout(timer);
     };
-  }, [file, meta?.duration, meta?.width, meta?.height, selected, uploadOriginal]);
+  }, [
+    audioBitrateKbps,
+    file,
+    meta?.duration,
+    meta?.width,
+    meta?.height,
+    selected,
+    uploadOriginal,
+    videoBitrates,
+    videoCodec,
+  ]);
 
   const onDrop = (event: DragEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -162,6 +227,12 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
     const resolutionsToUpload = orderedSelection(selected);
 
     const fd = new FormData();
+    const encodeSettings = buildEncodeSettings(
+      resolutionsToUpload,
+      videoCodec,
+      videoBitrates,
+      audioBitrateKbps,
+    );
     fd.append("file", file);
     fd.append("title", title.trim());
     fd.append("description", desc.trim());
@@ -170,6 +241,9 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
     fd.append("show_manifest_address", showManifestAddress ? "true" : "false");
     fd.append("upload_original", uploadOriginal ? "true" : "false");
     fd.append("publish_when_ready", publishWhenReady ? "true" : "false");
+    fd.append("video_codec", encodeSettings.video_codec);
+    fd.append("audio_bitrate_kbps", String(encodeSettings.audio_bitrate_kbps));
+    fd.append("video_bitrate_overrides", JSON.stringify(encodeSettings.video_bitrate_overrides));
 
     try {
       const data = await uploadVideo(fd, (progressEvent) => {
@@ -184,6 +258,9 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
       setUploadOriginal(false);
       setPublishWhenReady(false);
       setSelected(["720p"]);
+      setVideoCodec("h264");
+      setAudioBitrateKbps(DEFAULT_AUDIO_BITRATE_KBPS);
+      setVideoBitrates(defaultVideoBitrates("h264"));
       setMeta(null);
       setQuote({ loading: false, error: "", data: null });
       setProgress(0);
@@ -307,6 +384,81 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
             />
             <span>Publish automatically when ready</span>
           </label>
+        </div>
+
+        <div className="encoding-panel">
+          <div className="encoding-row">
+            <label>
+              <span>Video codec</span>
+              <select
+                value={videoCodec}
+                onChange={(event) => {
+                  const nextCodec = event.target.value as VideoCodec;
+                  const previousCodec = videoCodec;
+                  setVideoCodec(nextCodec);
+                  setVideoBitrates((current) => {
+                    const previousDefaults = defaultVideoBitrates(previousCodec);
+                    const nextDefaults = defaultVideoBitrates(nextCodec);
+                    return Object.fromEntries(
+                      RESOLUTION_OPTIONS.map((option) => {
+                        const currentValue = current[option.value];
+                        const nextValue = currentValue === previousDefaults[option.value]
+                          ? nextDefaults[option.value]
+                          : currentValue ?? nextDefaults[option.value];
+                        return [option.value, nextValue];
+                      }),
+                    );
+                  });
+                  setQuote({ loading: false, error: "", data: null });
+                }}
+                disabled={uploading}
+              >
+                <option value="h264">H.264</option>
+                <option value="hevc">HEVC / H.265</option>
+              </select>
+            </label>
+            <label>
+              <span>Audio bitrate</span>
+              <input
+                type="number"
+                min={32}
+                max={1024}
+                step={32}
+                value={audioBitrateKbps}
+                onChange={(event) => {
+                  setAudioBitrateKbps(Number(event.target.value));
+                  setQuote({ loading: false, error: "", data: null });
+                }}
+                disabled={uploading}
+              />
+            </label>
+          </div>
+          <div className="bitrate-grid">
+            {orderedSelection(selected).map((resolution) => {
+              const option = resolutionByValue(resolution);
+              return (
+                <label key={resolution}>
+                  <span>{option?.label || resolution}</span>
+                  <input
+                    type="number"
+                    min={64}
+                    max={200000}
+                    step={1}
+                    value={videoBitrates[resolution] || 0}
+                    onChange={(event) => {
+                      const nextValue = Number(event.target.value);
+                      setVideoBitrates((current) => ({
+                        ...current,
+                        [resolution]: nextValue,
+                      }));
+                      setQuote({ loading: false, error: "", data: null });
+                    }}
+                    disabled={uploading}
+                  />
+                </label>
+              );
+            })}
+          </div>
         </div>
 
         <div className="resolution-toolbar">

--- a/react_frontend/src/constants.ts
+++ b/react_frontend/src/constants.ts
@@ -5,14 +5,14 @@ export const PLAYER_CONTROLS_IDLE_MS = 2200;
 export const RESUME_DURATION_TOLERANCE_SECONDS = 0.25;
 
 export const RESOLUTION_OPTIONS: ResolutionOption[] = [
-  { value: "8k", label: "8K", width: 7680, height: 4320, bitrate: "~45 Mbps", note: "maximum archive" },
-  { value: "4k", label: "4K", width: 3840, height: 2160, bitrate: "~16 Mbps", note: "ultra HD" },
-  { value: "1440p", label: "1440P", width: 2560, height: 1440, bitrate: "~8 Mbps", note: "quad HD" },
-  { value: "1080p", label: "1080P", width: 1920, height: 1080, bitrate: "~5 Mbps", note: "full HD" },
-  { value: "720p", label: "720p", width: 1280, height: 720, bitrate: "~2.5 Mbps", note: "HD" },
-  { value: "540p", label: "540p", width: 960, height: 540, bitrate: "~1.6 Mbps", note: "qHD" },
-  { value: "480p", label: "480P", width: 854, height: 480, bitrate: "~1 Mbps", note: "mobile" },
-  { value: "360p", label: "360P", width: 640, height: 360, bitrate: "~500 kbps", note: "low bandwidth" },
-  { value: "240p", label: "240p", width: 426, height: 240, bitrate: "~300 kbps", note: "very low bandwidth" },
-  { value: "144p", label: "144p", width: 256, height: 144, bitrate: "~150 kbps", note: "minimum preview" },
+  { value: "8k", label: "8K", width: 7680, height: 4320, bitrate: "~80 Mbps", defaultVideoBitrateKbps: 80_000, note: "maximum archive" },
+  { value: "4k", label: "4K", width: 3840, height: 2160, bitrate: "~45 Mbps", defaultVideoBitrateKbps: 45_000, note: "ultra HD" },
+  { value: "1440p", label: "1440P", width: 2560, height: 1440, bitrate: "~24 Mbps", defaultVideoBitrateKbps: 24_000, note: "quad HD" },
+  { value: "1080p", label: "1080P", width: 1920, height: 1080, bitrate: "~12 Mbps", defaultVideoBitrateKbps: 12_000, note: "full HD" },
+  { value: "720p", label: "720p", width: 1280, height: 720, bitrate: "~7.5 Mbps", defaultVideoBitrateKbps: 7_500, note: "HD" },
+  { value: "540p", label: "540p", width: 960, height: 540, bitrate: "~4.5 Mbps", defaultVideoBitrateKbps: 4_500, note: "qHD" },
+  { value: "480p", label: "480P", width: 854, height: 480, bitrate: "~3 Mbps", defaultVideoBitrateKbps: 3_000, note: "mobile" },
+  { value: "360p", label: "360P", width: 640, height: 360, bitrate: "~1.5 Mbps", defaultVideoBitrateKbps: 1_500, note: "low bandwidth" },
+  { value: "240p", label: "240p", width: 426, height: 240, bitrate: "~800 kbps", defaultVideoBitrateKbps: 800, note: "very low bandwidth" },
+  { value: "144p", label: "144p", width: 256, height: 144, bitrate: "~350 kbps", defaultVideoBitrateKbps: 350, note: "minimum preview" },
 ];

--- a/react_frontend/src/styles/responsive.css
+++ b/react_frontend/src/styles/responsive.css
@@ -46,9 +46,14 @@
   }
 
   .source-panel,
+  .encoding-row,
   .form-grid,
   .login-grid {
     grid-template-columns: 1fr;
+  }
+
+  .bitrate-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .login-brand-panel {
@@ -121,6 +126,10 @@
   }
 
   .resolution-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bitrate-grid {
     grid-template-columns: 1fr;
   }
 

--- a/react_frontend/src/styles/upload.css
+++ b/react_frontend/src/styles/upload.css
@@ -199,6 +199,65 @@
   width: 16px;
 }
 
+.encoding-panel {
+  background: rgba(237, 241, 243, 0.72);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  margin-top: 18px;
+  padding: 16px;
+}
+
+.encoding-row {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 0.35fr);
+}
+
+.encoding-row label,
+.bitrate-grid label {
+  display: block;
+}
+
+.encoding-row span,
+.bitrate-grid span {
+  color: var(--muted);
+  display: block;
+  font-size: 12px;
+  font-weight: 950;
+  letter-spacing: 0.08em;
+  margin-bottom: 7px;
+  text-transform: uppercase;
+}
+
+.encoding-row input,
+.encoding-row select,
+.bitrate-grid input {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  color: var(--charcoal-strong);
+  min-height: 44px;
+  outline: none;
+  padding: 10px 12px;
+  transition: border-color 160ms ease, box-shadow 160ms ease, background 160ms ease;
+  width: 100%;
+}
+
+.encoding-row input:focus,
+.encoding-row select:focus,
+.bitrate-grid input:focus {
+  background: var(--surface);
+  border-color: rgba(232, 111, 25, 0.72);
+  box-shadow: 0 0 0 4px rgba(232, 111, 25, 0.12);
+}
+
+.bitrate-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  margin-top: 14px;
+}
+
 .resolution-toolbar {
   align-items: center;
   display: flex;

--- a/react_frontend/src/types.ts
+++ b/react_frontend/src/types.ts
@@ -24,6 +24,7 @@ export interface ResolutionOption {
   width: number;
   height: number;
   bitrate: string;
+  defaultVideoBitrateKbps: number;
   note: string;
 }
 
@@ -48,7 +49,11 @@ export interface VideoSummary {
 export interface VideoVariant {
   id: string;
   resolution: string;
+  audio_bitrate?: number;
+  segment_container?: string;
   segment_count?: number;
+  video_bitrate?: number;
+  video_codec?: string;
 }
 
 export interface QuoteOriginalFile {
@@ -119,11 +124,18 @@ export interface AdminCatalogs {
 
 export interface UploadQuoteRequest {
   duration_seconds: number;
+  encode_settings?: EncodeSettings;
   resolutions: string[];
   source_height: number | null;
   source_width: number | null;
   source_size_bytes?: number;
   upload_original?: boolean;
+}
+
+export interface EncodeSettings {
+  audio_bitrate_kbps?: number;
+  video_bitrate_overrides: Record<string, number>;
+  video_codec: "h264" | "hevc";
 }
 
 export interface VisibilityUpdate {

--- a/rust_admin/migrations/0002_encode_settings.sql
+++ b/rust_admin/migrations/0002_encode_settings.sql
@@ -1,0 +1,3 @@
+ALTER TABLE videos ADD COLUMN encode_settings TEXT;
+ALTER TABLE video_variants ADD COLUMN video_codec TEXT NOT NULL DEFAULT 'h264';
+ALTER TABLE video_variants ADD COLUMN segment_container TEXT NOT NULL DEFAULT 'mpegts';

--- a/rust_admin/src/catalog/db_document.rs
+++ b/rust_admin/src/catalog/db_document.rs
@@ -66,7 +66,8 @@ pub(crate) async fn db_video_to_out(
     let video_id: Uuid = row.try_get("id").map_err(db_error)?;
     let variant_rows = sqlx::query(
         r#"
-        SELECT id, resolution, width, height, total_duration, segment_count
+        SELECT id, resolution, width, height, video_bitrate, audio_bitrate,
+               video_codec, segment_container, total_duration, segment_count
         FROM video_variants WHERE video_id=$1 ORDER BY height DESC
         "#,
     )
@@ -102,6 +103,14 @@ pub(crate) async fn db_video_to_out(
         variants.push(VariantOut {
             id: variant_id.to_string(),
             resolution: variant.try_get("resolution").unwrap_or_default(),
+            video_codec: variant
+                .try_get::<String, _>("video_codec")
+                .unwrap_or_else(|_| "h264".to_string()),
+            segment_container: variant
+                .try_get::<String, _>("segment_container")
+                .unwrap_or_else(|_| "mpegts".to_string()),
+            video_bitrate: variant.try_get("video_bitrate").unwrap_or_default(),
+            audio_bitrate: variant.try_get("audio_bitrate").unwrap_or_default(),
             width: variant.try_get("width").unwrap_or_default(),
             height: variant.try_get("height").unwrap_or_default(),
             total_duration: variant.try_get("total_duration").ok().flatten(),
@@ -190,6 +199,12 @@ pub(crate) fn catalog_entry_to_video_out(entry: &Value, catalog_address: Option<
                     string_field(variant, "resolution")
                 ),
                 resolution: string_field(variant, "resolution"),
+                video_codec: opt_string_field(variant, "video_codec")
+                    .unwrap_or_else(|| "h264".to_string()),
+                segment_container: opt_string_field(variant, "segment_container")
+                    .unwrap_or_else(|| "mpegts".to_string()),
+                video_bitrate: int_field(variant, "video_bitrate"),
+                audio_bitrate: int_field(variant, "audio_bitrate"),
                 width: int_field(variant, "width"),
                 height: int_field(variant, "height"),
                 total_duration: variant.get("total_duration").and_then(Value::as_f64),
@@ -281,6 +296,12 @@ pub(crate) fn manifest_to_video_out(
             .map(|variant| VariantOut {
                 id: format!("{video_id}:{}", string_field(variant, "resolution")),
                 resolution: string_field(variant, "resolution"),
+                video_codec: opt_string_field(variant, "video_codec")
+                    .unwrap_or_else(|| "h264".to_string()),
+                segment_container: opt_string_field(variant, "segment_container")
+                    .unwrap_or_else(|| "mpegts".to_string()),
+                video_bitrate: int_field(variant, "video_bitrate"),
+                audio_bitrate: int_field(variant, "audio_bitrate"),
                 width: int_field(variant, "width"),
                 height: int_field(variant, "height"),
                 total_duration: variant.get("total_duration").and_then(Value::as_f64),
@@ -380,7 +401,7 @@ pub(super) async fn build_ready_manifest_from_db(
     let variants = sqlx::query(
         r#"
         SELECT id, resolution, width, height, video_bitrate, audio_bitrate,
-               segment_duration, total_duration
+               video_codec, segment_container, segment_duration, total_duration
         FROM video_variants
         WHERE video_id=$1
         ORDER BY height DESC
@@ -441,6 +462,12 @@ pub(super) async fn build_ready_manifest_from_db(
             resolution: variant
                 .try_get::<String, _>("resolution")
                 .unwrap_or_default(),
+            video_codec: variant
+                .try_get::<String, _>("video_codec")
+                .unwrap_or_else(|_| "h264".to_string()),
+            segment_container: variant
+                .try_get::<String, _>("segment_container")
+                .unwrap_or_else(|_| "mpegts".to_string()),
             width: variant.try_get::<i32, _>("width").unwrap_or_default(),
             height: variant.try_get::<i32, _>("height").unwrap_or_default(),
             video_bitrate: variant

--- a/rust_admin/src/jobs/lease_worker.rs
+++ b/rust_admin/src/jobs/lease_worker.rs
@@ -17,7 +17,7 @@ use crate::{
     catalog::publish_current_catalog_to_network,
     db::{db_error, set_status},
     errors::ApiError,
-    models::{JobKind, LeasedJob},
+    models::{EncodeSettings, JobKind, LeasedJob},
     pipeline::{process_video_inner, upload_approved_video_inner},
     state::AppState,
     JOB_STATUS_FAILED, JOB_STATUS_QUEUED, JOB_STATUS_RUNNING, JOB_STATUS_SUCCEEDED, STATUS_ERROR,
@@ -207,7 +207,7 @@ async fn run_process_video_job(state: &AppState, video_uuid: Option<Uuid>) -> Re
     let video_id = video_uuid.to_string();
     let row = sqlx::query(
         r#"
-        SELECT status, job_dir, job_source_path, requested_resolutions
+        SELECT status, job_dir, job_source_path, requested_resolutions, encode_settings
         FROM videos
         WHERE id=$1
         "#,
@@ -256,8 +256,24 @@ async fn run_process_video_job(state: &AppState, video_uuid: Option<Uuid>) -> Re
             "Processing job has no supported requested resolutions",
         ));
     }
+    let encode_settings = decode_encode_settings(row.try_get("encode_settings").map_err(db_error)?);
 
-    process_video_inner(state, &video_id, &source_path, &resolutions, &job_dir, true).await
+    process_video_inner(
+        state,
+        &video_id,
+        &source_path,
+        &resolutions,
+        &job_dir,
+        true,
+        &encode_settings,
+    )
+    .await
+}
+
+fn decode_encode_settings(value: Option<serde_json::Value>) -> EncodeSettings {
+    value
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default()
 }
 
 #[instrument(skip(state), fields(video_id = ?video_uuid))]

--- a/rust_admin/src/media.rs
+++ b/rust_admin/src/media.rs
@@ -14,10 +14,18 @@ use tracing::{info, instrument};
 use crate::{
     config::duration_from_secs_f64,
     errors::ApiError,
-    models::{CommandOutput, TranscodedRendition, TranscodedSegment, UploadMediaMetadata},
+    models::{
+        CommandOutput, EncodeSettings, TranscodedRendition, TranscodedSegment, UploadMediaMetadata,
+        VideoCodec,
+    },
     state::AppState,
     MIN_ANTD_SELF_ENCRYPTION_BYTES, SUPPORTED_RESOLUTIONS,
 };
+
+const MIN_VIDEO_BITRATE_KBPS: i32 = 64;
+const MAX_VIDEO_BITRATE_KBPS: i32 = 200_000;
+const MIN_AUDIO_BITRATE_KBPS: i32 = 32;
+const MAX_AUDIO_BITRATE_KBPS: i32 = 1_024;
 
 pub(crate) async fn run_command_output(
     mut command: Command,
@@ -229,10 +237,7 @@ async fn run_ffmpeg(
     state: &AppState,
     src: &FsPath,
     seg_dir: &FsPath,
-    width: i32,
-    height: i32,
-    video_kbps: i32,
-    audio_kbps: i32,
+    target: &RenditionTarget,
 ) -> Result<(), ApiError> {
     let src = assert_under(src, &state.config.upload_temp_dir)?;
     let seg_dir = assert_under(seg_dir, &state.config.upload_temp_dir)?;
@@ -245,10 +250,11 @@ async fn run_ffmpeg(
         filter_threads: state.config.ffmpeg_filter_threads,
         ffmpeg_threads: state.config.ffmpeg_threads,
         hls_segment_duration: state.config.hls_segment_duration,
-        width,
-        height,
-        video_kbps,
-        audio_kbps,
+        video_codec: target.video_codec,
+        width: target.width,
+        height: target.height,
+        video_kbps: target.video_kbps,
+        audio_kbps: target.audio_kbps,
     }));
     let output =
         run_command_output(command, Some(state.config.ffmpeg_rendition_timeout_seconds)).await?;
@@ -277,6 +283,23 @@ struct FfmpegTranscodeOptions<'a> {
     filter_threads: usize,
     ffmpeg_threads: usize,
     hls_segment_duration: f64,
+    video_codec: VideoCodec,
+    width: i32,
+    height: i32,
+    video_kbps: i32,
+    audio_kbps: i32,
+}
+
+#[derive(Clone)]
+struct TranscodeRenditionInput {
+    order: usize,
+    resolution: String,
+    source_dimensions: Option<(i32, i32)>,
+    encode_settings: EncodeSettings,
+}
+
+struct RenditionTarget {
+    video_codec: VideoCodec,
     width: i32,
     height: i32,
     video_kbps: i32,
@@ -285,6 +308,41 @@ struct FfmpegTranscodeOptions<'a> {
 
 fn ffmpeg_transcode_args(options: FfmpegTranscodeOptions<'_>) -> Vec<OsString> {
     let segment_time = format!("{}", F64Format(options.hls_segment_duration));
+    let codec_args: Vec<OsString> = match options.video_codec {
+        VideoCodec::H264 => [
+            "-c:v",
+            "libx264",
+            "-threads",
+            &options.ffmpeg_threads.to_string(),
+            "-preset",
+            "veryfast",
+            "-profile:v",
+            "high",
+            "-pix_fmt",
+            "yuv420p",
+        ]
+        .into_iter()
+        .map(OsString::from)
+        .collect(),
+        VideoCodec::Hevc => [
+            "-c:v",
+            "libx265",
+            "-threads",
+            &options.ffmpeg_threads.to_string(),
+            "-preset",
+            "medium",
+            "-tag:v",
+            "hvc1",
+            "-pix_fmt",
+            "yuv420p",
+            "-x265-params",
+            "log-level=error",
+        ]
+        .into_iter()
+        .map(OsString::from)
+        .collect(),
+    };
+
     [
         "-hide_banner",
         "-nostats",
@@ -299,22 +357,13 @@ fn ffmpeg_transcode_args(options: FfmpegTranscodeOptions<'_>) -> Vec<OsString> {
     .map(OsString::from)
     .chain([options.src.as_os_str().to_owned()])
     .chain(
+        ["-map", "0:v:0", "-map", "0:a?", "-sn"]
+            .into_iter()
+            .map(OsString::from),
+    )
+    .chain(codec_args)
+    .chain(
         [
-            "-map",
-            "0:v:0",
-            "-map",
-            "0:a?",
-            "-sn",
-            "-c:v",
-            "libx264",
-            "-threads",
-            &options.ffmpeg_threads.to_string(),
-            "-preset",
-            "veryfast",
-            "-profile:v",
-            "high",
-            "-pix_fmt",
-            "yuv420p",
             "-vf",
             &format!(
                 "scale={}:{}:force_original_aspect_ratio=decrease,pad={}:{}:(ow-iw)/2:(oh-ih)/2",
@@ -486,6 +535,7 @@ pub(crate) async fn transcode_renditions(
     resolutions: &[String],
     job_dir: &FsPath,
     source_dimensions: Option<(i32, i32)>,
+    encode_settings: &EncodeSettings,
 ) -> Result<Vec<TranscodedRendition>, ApiError> {
     let semaphore = Arc::new(Semaphore::new(state.config.ffmpeg_max_parallel_renditions));
     let mut jobs = JoinSet::new();
@@ -501,6 +551,7 @@ pub(crate) async fn transcode_renditions(
         let source_path = source_path.to_path_buf();
         let job_dir = job_dir.to_path_buf();
         let resolution = resolution.clone();
+        let encode_settings = encode_settings.clone();
         scheduled += 1;
         jobs.spawn(async move {
             let _permit = semaphore.acquire_owned().await.map_err(|err| {
@@ -509,16 +560,13 @@ pub(crate) async fn transcode_renditions(
                     format!("Could not acquire FFmpeg rendition slot: {err}"),
                 )
             })?;
-            transcode_one_rendition(
-                &state,
-                &video_id,
-                &source_path,
-                &job_dir,
+            let input = TranscodeRenditionInput {
                 order,
                 resolution,
                 source_dimensions,
-            )
-            .await
+                encode_settings,
+            };
+            transcode_one_rendition(&state, &video_id, &source_path, &job_dir, input).await
         });
     }
 
@@ -555,19 +603,20 @@ pub(crate) async fn transcode_renditions(
     Ok(renditions)
 }
 
-#[instrument(
-    skip(state, source_path, job_dir),
-    fields(video_id = %video_id, resolution = %resolution, order = order)
-)]
+#[instrument(skip(state, source_path, job_dir, input), fields(video_id = %video_id))]
 async fn transcode_one_rendition(
     state: &AppState,
     video_id: &str,
     source_path: &FsPath,
     job_dir: &FsPath,
-    order: usize,
-    resolution: String,
-    source_dimensions: Option<(i32, i32)>,
+    input: TranscodeRenditionInput,
 ) -> Result<TranscodedRendition, ApiError> {
+    let TranscodeRenditionInput {
+        order,
+        resolution,
+        source_dimensions,
+        encode_settings,
+    } = input;
     let Some((preset_width, preset_height, video_kbps, audio_kbps)) =
         resolution_preset(&resolution)
     else {
@@ -578,8 +627,23 @@ async fn transcode_one_rendition(
     };
     let (width, height) =
         target_dimensions_for_source(preset_width, preset_height, source_dimensions);
+    let base_video_kbps = encode_settings
+        .video_bitrate_overrides
+        .get(&resolution)
+        .copied()
+        .unwrap_or_else(|| {
+            default_video_bitrate_for_codec(video_kbps, encode_settings.video_codec)
+        });
     let video_kbps =
-        target_video_bitrate_kbps(video_kbps, preset_width, preset_height, width, height);
+        target_video_bitrate_kbps(base_video_kbps, preset_width, preset_height, width, height);
+    let audio_kbps = encode_settings.audio_bitrate_kbps.unwrap_or(audio_kbps);
+    let target = RenditionTarget {
+        video_codec: encode_settings.video_codec,
+        width,
+        height,
+        video_kbps,
+        audio_kbps,
+    };
     let seg_dir = job_dir.join(&resolution);
     fs::create_dir_all(&seg_dir).map_err(|err| {
         ApiError::new(
@@ -589,16 +653,7 @@ async fn transcode_one_rendition(
     })?;
     info!("Transcoding {} -> {}", video_id, resolution);
     let ffmpeg_started = Instant::now();
-    let ffmpeg_result = run_ffmpeg(
-        state,
-        source_path,
-        &seg_dir,
-        width,
-        height,
-        video_kbps,
-        audio_kbps,
-    )
-    .await;
+    let ffmpeg_result = run_ffmpeg(state, source_path, &seg_dir, &target).await;
     state
         .metrics
         .record_ffmpeg_duration(&resolution, ffmpeg_started.elapsed());
@@ -648,10 +703,12 @@ async fn transcode_one_rendition(
     Ok(TranscodedRendition {
         order,
         resolution,
-        width,
-        height,
-        video_kbps,
-        audio_kbps,
+        width: target.width,
+        height: target.height,
+        video_kbps: target.video_kbps,
+        audio_kbps: target.audio_kbps,
+        video_codec: target.video_codec,
+        segment_container: "mpegts".to_string(),
         segments,
     })
 }
@@ -679,18 +736,76 @@ fn segment_index_from_path(path: &FsPath) -> Option<i32> {
 }
 pub(crate) fn resolution_preset(resolution: &str) -> Option<(i32, i32, i32, i32)> {
     match resolution {
-        "8k" => Some((7680, 4320, 45000, 320)),
-        "4k" => Some((3840, 2160, 16000, 256)),
-        "1440p" => Some((2560, 1440, 8000, 192)),
-        "1080p" => Some((1920, 1080, 5000, 192)),
-        "720p" => Some((1280, 720, 2500, 128)),
-        "540p" => Some((960, 540, 1600, 128)),
-        "480p" => Some((854, 480, 1000, 128)),
-        "360p" => Some((640, 360, 500, 96)),
-        "240p" => Some((426, 240, 300, 64)),
-        "144p" => Some((256, 144, 150, 48)),
+        "8k" => Some((7680, 4320, 80_000, 320)),
+        "4k" => Some((3840, 2160, 45_000, 320)),
+        "1440p" => Some((2560, 1440, 24_000, 320)),
+        "1080p" => Some((1920, 1080, 12_000, 256)),
+        "720p" => Some((1280, 720, 7_500, 192)),
+        "540p" => Some((960, 540, 4_500, 160)),
+        "480p" => Some((854, 480, 3_000, 160)),
+        "360p" => Some((640, 360, 1_500, 128)),
+        "240p" => Some((426, 240, 800, 96)),
+        "144p" => Some((256, 144, 350, 64)),
         _ => None,
     }
+}
+
+pub(crate) fn validate_encode_settings(
+    settings: &EncodeSettings,
+    selected_resolutions: &[String],
+) -> Result<(), ApiError> {
+    if let Some(audio_kbps) = settings.audio_bitrate_kbps {
+        if !(MIN_AUDIO_BITRATE_KBPS..=MAX_AUDIO_BITRATE_KBPS).contains(&audio_kbps) {
+            return Err(ApiError::new(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "audio_bitrate_kbps must be between {MIN_AUDIO_BITRATE_KBPS} and {MAX_AUDIO_BITRATE_KBPS}"
+                ),
+            ));
+        }
+    }
+
+    for (resolution, video_kbps) in &settings.video_bitrate_overrides {
+        if !selected_resolutions.iter().any(|value| value == resolution) {
+            return Err(ApiError::new(
+                StatusCode::BAD_REQUEST,
+                format!("video bitrate override references unselected resolution '{resolution}'"),
+            ));
+        }
+        if resolution_preset(resolution).is_none() {
+            return Err(ApiError::new(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "video bitrate override references unsupported resolution '{resolution}'. {}",
+                    supported_resolutions_error()
+                ),
+            ));
+        }
+        let max_video_bitrate_kbps = max_video_bitrate_override_kbps(resolution);
+        if !(MIN_VIDEO_BITRATE_KBPS..=max_video_bitrate_kbps).contains(video_kbps) {
+            return Err(ApiError::new(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "video bitrate for {resolution} must be between {MIN_VIDEO_BITRATE_KBPS} and {max_video_bitrate_kbps} kbps"
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn default_video_bitrate_for_codec(base_video_kbps: i32, codec: VideoCodec) -> i32 {
+    match codec {
+        VideoCodec::H264 => base_video_kbps,
+        VideoCodec::Hevc => (base_video_kbps * 7 / 10).max(MIN_VIDEO_BITRATE_KBPS),
+    }
+}
+
+fn max_video_bitrate_override_kbps(resolution: &str) -> i32 {
+    resolution_preset(resolution)
+        .map(|(_, _, video_kbps, _)| (video_kbps * 4).min(MAX_VIDEO_BITRATE_KBPS))
+        .unwrap_or(MAX_VIDEO_BITRATE_KBPS)
 }
 
 pub(crate) fn supported_resolutions_error() -> String {
@@ -812,8 +927,9 @@ mod tests {
     use super::{
         assert_under, collect_segment_files, estimate_transcoded_bytes, ffmpeg_transcode_args,
         parse_probe_duration, stream_rotation_degrees, target_dimensions_for_source,
-        target_video_bitrate_kbps, FfmpegTranscodeOptions,
+        target_video_bitrate_kbps, validate_encode_settings, FfmpegTranscodeOptions,
     };
+    use crate::models::{EncodeSettings, VideoCodec};
 
     #[test]
     fn target_dimensions_follow_source_orientation() {
@@ -881,6 +997,26 @@ mod tests {
     }
 
     #[test]
+    fn validate_encode_settings_rejects_unselected_and_excessive_bitrates() {
+        let selected = vec!["720p".to_string()];
+        let mut settings = EncodeSettings::default();
+        settings
+            .video_bitrate_overrides
+            .insert("1080p".to_string(), 12_000);
+        let err = validate_encode_settings(&settings, &selected).unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert!(err.detail.contains("unselected resolution"));
+
+        let mut settings = EncodeSettings::default();
+        settings
+            .video_bitrate_overrides
+            .insert("144p".to_string(), 200_000);
+        let err = validate_encode_settings(&settings, &["144p".to_string()]).unwrap_err();
+        assert_eq!(err.status, StatusCode::BAD_REQUEST);
+        assert!(err.detail.contains("between 64 and 1400"));
+    }
+
+    #[test]
     fn collect_segment_files_orders_numbered_segments_only() {
         let dir = std::env::temp_dir().join(format!("autvid_segments_{}", Uuid::new_v4()));
         fs::create_dir_all(&dir).unwrap();
@@ -908,6 +1044,7 @@ mod tests {
             filter_threads: 1,
             ffmpeg_threads: 2,
             hls_segment_duration: 1.0,
+            video_codec: VideoCodec::H264,
             width: 640,
             height: 360,
             video_kbps: 500,
@@ -925,6 +1062,28 @@ mod tests {
             args.get(reset_timestamp_index + 1).map(String::as_str),
             Some("0")
         );
+    }
+
+    #[test]
+    fn ffmpeg_hevc_args_use_x265_and_hvc1_tag() {
+        let args = ffmpeg_transcode_args(FfmpegTranscodeOptions {
+            src: Path::new("/tmp/source.mp4"),
+            segment_pattern: Path::new("/tmp/seg_%05d.ts"),
+            filter_threads: 1,
+            ffmpeg_threads: 2,
+            hls_segment_duration: 1.0,
+            video_codec: VideoCodec::Hevc,
+            width: 640,
+            height: 360,
+            video_kbps: 500,
+            audio_kbps: 96,
+        })
+        .into_iter()
+        .map(|arg| arg.to_string_lossy().to_string())
+        .collect::<Vec<_>>();
+
+        assert!(args.windows(2).any(|pair| pair == ["-c:v", "libx265"]));
+        assert!(args.windows(2).any(|pair| pair == ["-tag:v", "hvc1"]));
     }
 
     #[test]

--- a/rust_admin/src/models.rs
+++ b/rust_admin/src/models.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -52,6 +52,42 @@ pub(crate) struct UploadQuoteRequest {
     #[serde(default)]
     pub(crate) upload_original: bool,
     pub(crate) source_size_bytes: Option<i64>,
+    #[serde(default)]
+    pub(crate) encode_settings: EncodeSettings,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum VideoCodec {
+    #[default]
+    H264,
+    Hevc,
+}
+
+impl VideoCodec {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::H264 => "h264",
+            Self::Hevc => "hevc",
+        }
+    }
+
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "h264" | "h.264" | "avc" => Some(Self::H264),
+            "hevc" | "h265" | "h.265" => Some(Self::Hevc),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub(crate) struct EncodeSettings {
+    #[serde(default)]
+    pub(crate) video_codec: VideoCodec,
+    #[serde(default)]
+    pub(crate) video_bitrate_overrides: HashMap<String, i32>,
+    pub(crate) audio_bitrate_kbps: Option<i32>,
 }
 
 #[derive(Serialize, Clone)]
@@ -65,6 +101,10 @@ pub(crate) struct SegmentOut {
 pub(crate) struct VariantOut {
     pub(crate) id: String,
     pub(crate) resolution: String,
+    pub(crate) video_codec: String,
+    pub(crate) segment_container: String,
+    pub(crate) video_bitrate: i32,
+    pub(crate) audio_bitrate: i32,
     pub(crate) width: i32,
     pub(crate) height: i32,
     pub(crate) total_duration: Option<f64>,
@@ -163,6 +203,10 @@ pub(crate) struct ManifestOriginalFile {
 pub(crate) struct ManifestVariant {
     pub(crate) id: String,
     pub(crate) resolution: String,
+    #[serde(default = "default_video_codec")]
+    pub(crate) video_codec: String,
+    #[serde(default = "default_segment_container")]
+    pub(crate) segment_container: String,
     pub(crate) width: i32,
     pub(crate) height: i32,
     pub(crate) video_bitrate: i32,
@@ -277,6 +321,8 @@ pub(crate) struct TranscodedRendition {
     pub(crate) height: i32,
     pub(crate) video_kbps: i32,
     pub(crate) audio_kbps: i32,
+    pub(crate) video_codec: VideoCodec,
+    pub(crate) segment_container: String,
     pub(crate) segments: Vec<TranscodedSegment>,
 }
 
@@ -294,6 +340,14 @@ pub(crate) struct QuoteValue {
     pub(crate) estimated_gas_cost_wei: u128,
     pub(crate) chunk_count: i64,
     pub(crate) payment_mode: String,
+}
+
+fn default_video_codec() -> String {
+    "h264".to_string()
+}
+
+fn default_segment_container() -> String {
+    "mpegts".to_string()
 }
 
 #[cfg(test)]
@@ -406,6 +460,8 @@ mod tests {
             variants: vec![ManifestVariant {
                 id: "variant-1".to_string(),
                 resolution: "720p".to_string(),
+                video_codec: "h264".to_string(),
+                segment_container: "mpegts".to_string(),
                 width: 1280,
                 height: 720,
                 video_bitrate: 2_500_000,
@@ -441,6 +497,8 @@ mod tests {
                 "variants": [{
                     "id": "variant-1",
                     "resolution": "720p",
+                    "video_codec": "h264",
+                    "segment_container": "mpegts",
                     "width": 1280,
                     "height": 720,
                     "video_bitrate": 2500000,

--- a/rust_admin/src/pipeline.rs
+++ b/rust_admin/src/pipeline.rs
@@ -24,7 +24,8 @@ use crate::{
     jobs::schedule_catalog_publish,
     media::{assert_under, probe_duration, probe_video_dimensions, transcode_renditions},
     models::{
-        ManifestOriginalFile, ManifestSegment, ManifestVariant, QuoteValue, VideoManifestDocument,
+        EncodeSettings, ManifestOriginalFile, ManifestSegment, ManifestVariant, QuoteValue,
+        VideoManifestDocument,
     },
     quote::{parse_cost_u128, quote_data_size},
     state::AppState,
@@ -43,6 +44,7 @@ pub(crate) async fn process_video_inner(
     resolutions: &[String],
     job_dir: &FsPath,
     reset_existing: bool,
+    encode_settings: &EncodeSettings,
 ) -> Result<(), ApiError> {
     let video_uuid = parse_video_uuid(video_id)?;
     if reset_existing {
@@ -79,6 +81,7 @@ pub(crate) async fn process_video_inner(
         resolutions,
         job_dir,
         source_dimensions,
+        encode_settings,
     )
     .await?;
 
@@ -88,8 +91,8 @@ pub(crate) async fn process_video_inner(
             r#"
             INSERT INTO video_variants
                 (id, video_id, resolution, width, height, video_bitrate, audio_bitrate,
-                 segment_duration, total_duration, segment_count)
-            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+                 video_codec, segment_container, segment_duration, total_duration, segment_count)
+            VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
             RETURNING id
         "#,
         )
@@ -100,6 +103,8 @@ pub(crate) async fn process_video_inner(
         .bind(rendition.height)
         .bind(rendition.video_kbps * 1000)
         .bind(rendition.audio_kbps * 1000)
+        .bind(rendition.video_codec.as_str())
+        .bind(&rendition.segment_container)
         .bind(state.config.hls_segment_duration)
         .bind(total_duration)
         .bind(rendition.segments.len() as i32)
@@ -528,7 +533,7 @@ pub(crate) async fn upload_approved_video_inner(
     let variants = sqlx::query(
         r#"
         SELECT id, resolution, width, height, video_bitrate, audio_bitrate,
-               segment_duration, total_duration
+               video_codec, segment_container, segment_duration, total_duration
         FROM video_variants
         WHERE video_id=$1
         ORDER BY height DESC
@@ -785,6 +790,12 @@ pub(crate) async fn upload_approved_video_inner(
             resolution: variant
                 .try_get::<String, _>("resolution")
                 .unwrap_or_default(),
+            video_codec: variant
+                .try_get::<String, _>("video_codec")
+                .unwrap_or_else(|_| "h264".to_string()),
+            segment_container: variant
+                .try_get::<String, _>("segment_container")
+                .unwrap_or_else(|_| "mpegts".to_string()),
             width: variant.try_get::<i32, _>("width").unwrap_or_default(),
             height: variant.try_get::<i32, _>("height").unwrap_or_default(),
             video_bitrate: variant

--- a/rust_admin/src/quote.rs
+++ b/rust_admin/src/quote.rs
@@ -3,8 +3,9 @@ use axum::http::StatusCode;
 use crate::{
     errors::ApiError,
     media::{
-        enforce_upload_media_limits, estimate_transcoded_bytes, resolution_preset,
-        supported_resolutions_error, target_dimensions_for_source, target_video_bitrate_kbps,
+        default_video_bitrate_for_codec, enforce_upload_media_limits, estimate_transcoded_bytes,
+        resolution_preset, supported_resolutions_error, target_dimensions_for_source,
+        target_video_bitrate_kbps, validate_encode_settings,
     },
     models::{
         QuoteValue, UploadQuoteOriginalOut, UploadQuoteOut, UploadQuoteRequest,
@@ -177,6 +178,7 @@ pub(crate) async fn build_upload_quote(
             supported_resolutions_error(),
         ));
     }
+    validate_encode_settings(&request.encode_settings, &request.resolutions)?;
 
     let mut quote_cache = std::collections::HashMap::new();
     let mut variants = Vec::new();
@@ -190,8 +192,20 @@ pub(crate) async fn build_upload_quote(
     for (resolution, (preset_width, preset_height, video_kbps, audio_kbps)) in selected {
         let (width, height) =
             target_dimensions_for_source(preset_width, preset_height, source_dimensions);
+        let base_video_kbps = request
+            .encode_settings
+            .video_bitrate_overrides
+            .get(&resolution)
+            .copied()
+            .unwrap_or_else(|| {
+                default_video_bitrate_for_codec(video_kbps, request.encode_settings.video_codec)
+            });
         let video_kbps =
-            target_video_bitrate_kbps(video_kbps, preset_width, preset_height, width, height);
+            target_video_bitrate_kbps(base_video_kbps, preset_width, preset_height, width, height);
+        let audio_kbps = request
+            .encode_settings
+            .audio_bitrate_kbps
+            .unwrap_or(audio_kbps);
         let full_segments =
             (request.duration_seconds / state.config.hls_segment_duration).floor() as i64;
         let mut remainder =

--- a/rust_admin/src/upload.rs
+++ b/rust_admin/src/upload.rs
@@ -24,9 +24,9 @@ use crate::{
     errors::ApiError,
     media::{
         enforce_upload_media_limits, probe_upload_media, resolution_preset,
-        supported_resolutions_error,
+        supported_resolutions_error, validate_encode_settings,
     },
-    models::{AcceptedUpload, UploadMediaMetadata},
+    models::{AcceptedUpload, EncodeSettings, UploadMediaMetadata, VideoCodec},
     state::AppState,
 };
 
@@ -106,6 +106,9 @@ pub(crate) async fn accept_upload(
     let mut show_manifest_address = false;
     let mut upload_original = false;
     let mut publish_when_ready = false;
+    let mut video_codec = VideoCodec::default();
+    let mut audio_bitrate_kbps: Option<i32> = None;
+    let mut video_bitrate_overrides = std::collections::HashMap::new();
     let mut original_filename: Option<String> = None;
     let mut source_path: Option<PathBuf> = None;
     let mut upload_metadata: Option<UploadMediaMetadata> = None;
@@ -205,6 +208,17 @@ pub(crate) async fn accept_upload(
                 "show_manifest_address" => show_manifest_address = parse_form_bool(&text),
                 "upload_original" => upload_original = parse_form_bool(&text),
                 "publish_when_ready" => publish_when_ready = parse_form_bool(&text),
+                "video_codec" => {
+                    video_codec = VideoCodec::parse(&text).ok_or_else(|| {
+                        ApiError::new(StatusCode::BAD_REQUEST, "video_codec must be h264 or hevc")
+                    })?;
+                }
+                "audio_bitrate_kbps" => {
+                    audio_bitrate_kbps = Some(parse_kbps_field(&text, "audio_bitrate_kbps")?);
+                }
+                "video_bitrate_overrides" => {
+                    video_bitrate_overrides = parse_video_bitrate_overrides(&text)?;
+                }
                 _ => {}
             }
         }
@@ -224,6 +238,12 @@ pub(crate) async fn accept_upload(
             supported_resolutions_error(),
         ));
     }
+    let encode_settings = EncodeSettings {
+        video_codec,
+        video_bitrate_overrides,
+        audio_bitrate_kbps,
+    };
+    validate_encode_settings(&encode_settings, &selected)?;
     if let Some(metadata) = upload_metadata {
         enforce_upload_media_limits(
             state,
@@ -238,10 +258,11 @@ pub(crate) async fn accept_upload(
         INSERT INTO videos (
             id, title, original_filename, description, status, job_dir,
             job_source_path, requested_resolutions,
+            encode_settings,
             show_original_filename, show_manifest_address,
             upload_original, publish_when_ready, user_id
         )
-        VALUES ($1, $2, $3, $4, 'pending', $5, $6, $7, $8, $9, $10, $11, $12)
+        VALUES ($1, $2, $3, $4, 'pending', $5, $6, $7, $8, $9, $10, $11, $12, $13)
         "#,
     )
     .bind(video_uuid)
@@ -255,6 +276,7 @@ pub(crate) async fn accept_upload(
     .bind(job_dir.to_string_lossy().as_ref())
     .bind(source_path.to_string_lossy().as_ref())
     .bind(json!(selected))
+    .bind(json!(encode_settings))
     .bind(false)
     .bind(show_manifest_address)
     .bind(upload_original)
@@ -267,6 +289,30 @@ pub(crate) async fn accept_upload(
     let video = get_db_video(state, &video_id, false).await?;
     guard.disarm();
     Ok(AcceptedUpload { video_id, video })
+}
+
+fn parse_kbps_field(text: &str, field_name: &str) -> Result<i32, ApiError> {
+    text.trim().parse::<i32>().map_err(|_| {
+        ApiError::new(
+            StatusCode::BAD_REQUEST,
+            format!("{field_name} must be an integer kbps value"),
+        )
+    })
+}
+
+fn parse_video_bitrate_overrides(
+    text: &str,
+) -> Result<std::collections::HashMap<String, i32>, ApiError> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    serde_json::from_str::<std::collections::HashMap<String, i32>>(trimmed).map_err(|_| {
+        ApiError::new(
+            StatusCode::BAD_REQUEST,
+            "video_bitrate_overrides must be a JSON object of resolution to kbps",
+        )
+    })
 }
 
 fn content_length(headers: &HeaderMap) -> Option<u64> {


### PR DESCRIPTION
## Summary
- Adds upload-time encoder settings for video codec, per-rendition video bitrate, and audio bitrate.
- Raises the default H.264 rendition ladder to higher quality defaults and derives lower HEVC defaults when HEVC is selected.
- Persists encode settings for durable processing recovery and records codec/container/bitrate metadata in variant rows and video manifests.
- Updates upload quote estimation and upload submission to use the same settings.

## Notes
- HEVC/H.265 is exposed as an option while keeping the current HLS MPEG-TS segment pipeline and routes. Local FFmpeg can emit the segments, but playback compatibility is still more limited than H.264 and a future fMP4/CMAF HLS migration would be the cleaner HEVC path.

## Validation
- `make fmt-rust`
- `cargo test -p rust_admin`
- `cargo test -p rust_stream`
- `make lint-react`
- `make test-react`
- `make build-react`
- `make clippy-rust`
- `make test-rust`
- Local FFmpeg HEVC segment smoke test with `libx265` and MPEG-TS output
