### PR TITLE
Update Autonomi clients and devnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "ant-core"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a73da60002c4da9d379264a955a8fca2e090d3d9ced3a5ffacbb6c3e87a205"
+checksum = "f36a0c4c5bf384aa92f635e3cd979b23a330cbcfbe22971be80a5c2894893741"
 dependencies = [
  "ant-protocol",
  "async-stream",
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be733b3b7f5b255fae1a315e24127e385c845677cd7aba1f1cde19e791f04976"
+checksum = "b7e57398bdba4060e26a0114f1af4fc3ec8f401a1676b4899aa047d1924d075d"
 dependencies = [
  "ant-protocol",
  "blake3",
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e950d12c9f6d08d0ea560573729d93f15e105d53b669defa682f5e6f92da4b1"
+checksum = "f61260c89bbc0039e0643f3e2ec79b1c17aee9d81b58d7edbc52314689489f39"
 dependencies = [
  "blake3",
  "bytes",
@@ -3357,7 +3357,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -5563,9 +5563,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.24.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f8952fc5a4d37eb0bca7de0740830f40347f9da663effde3ddd6b68bcd2fb"
+checksum = "fa8cc1b7f59f97d018760ff150bbb4f217197c41622b83f7085c9cf0424b736e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5678,9 +5678,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.34.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852400712537856ab6fec5293be4290daf0130df0dbcb249a6e8280f9257665f"
+checksum = "621d0a207914a8fd6453f25e4bcc369914cbfaf59a2857e898c079b95f52f5bb"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/antd_service/Cargo.toml
+++ b/antd_service/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow.workspace = true
-ant-core = "=0.2.7"
-ant-node = "=0.12.0"
+ant-core = "=0.2.8"
+ant-node = "=0.13.0"
 autvid_common = { path = "../common" }
 axum.workspace = true
 base64.workspace = true

--- a/autonomi_devnet/Dockerfile
+++ b/autonomi_devnet/Dockerfile
@@ -1,8 +1,8 @@
 # ── Stage 1: Build local Autonomi devnet tooling ─────────────────────────────
 FROM rust:1.96-slim-bookworm AS builder
 
-ARG AUTONOMI_ANT_SDK_REF=v0.9.2
-ARG AUTONOMI_ANT_NODE_REF=v0.12.0
+ARG AUTONOMI_ANT_SDK_REF=v0.10.0
+ARG AUTONOMI_ANT_NODE_REF=v0.13.0
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -36,18 +36,21 @@ COPY common/Cargo.toml common/Cargo.toml
 COPY rust_admin/Cargo.toml rust_admin/Cargo.toml
 COPY rust_stream/Cargo.toml rust_stream/Cargo.toml
 COPY antd_service/Cargo.toml antd_service/Cargo.toml
+COPY launcher_core/Cargo.toml launcher_core/Cargo.toml
 COPY standalone_launcher/Cargo.toml standalone_launcher/Cargo.toml
-RUN mkdir -p common/src rust_admin/src rust_stream/src antd_service/src standalone_launcher/src && \
+RUN mkdir -p common/src rust_admin/src rust_stream/src antd_service/src launcher_core/src standalone_launcher/src && \
     echo "" > common/src/lib.rs && \
     echo "fn main(){}" > rust_admin/src/main.rs && \
     echo "fn main(){}" > rust_stream/src/main.rs && \
     echo "fn main(){}" > antd_service/src/main.rs && \
+    echo "" > launcher_core/src/lib.rs && \
     echo "fn main(){}" > standalone_launcher/src/main.rs && \
     cargo build --release -p antd
 
 COPY common/src common/src
 COPY antd_service/src antd_service/src
-RUN touch common/src/lib.rs antd_service/src/main.rs && \
+COPY launcher_core/src launcher_core/src
+RUN touch common/src/lib.rs antd_service/src/main.rs launcher_core/src/lib.rs && \
     cargo build --release -p antd && \
     cp target/release/antd /usr/local/bin/autvid-antd-gateway
 

--- a/desktop_app/src-tauri/Cargo.lock
+++ b/desktop_app/src-tauri/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
 ]
 
@@ -3024,7 +3024,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3059,7 +3059,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4270,6 +4270,24 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.13.0",
  "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
  "futures-core",
  "futures-util",
  "http",
@@ -4283,10 +4301,8 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
  "tower-layer",
  "tower-service",
- "url",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update the local Autonomi gateway dependencies to `ant-core =0.2.8` and `ant-node =0.13.0`.
- Update the devnet build tags to `ant-sdk v0.10.0` and `ant-node v0.13.0` so the local test network matches the client side.
- Fix the devnet Docker cache/build stage to include the `launcher_core` workspace member, which clean rebuilds now require.
- Refresh the workspace and desktop Tauri lockfiles after rebasing onto the recent dependency-update PRs.

## Verification
- `cargo update -p ant-core --precise 0.2.8`
- `cargo update -p ant-node --precise 0.13.0`
- `make fmt-rust`
- `make compose-config`
- `make test-rust`
- `make clippy-rust`
- `AUTVID_ALLOW_SYSTEM_FFMPEG=1 AUTVID_ALLOW_DYNAMIC_FFMPEG=1 make build-tauri`
- Reinstalled `/Applications/Autonomi Video Management.app` from the rebuilt Tauri app bundle
- `make up-local`
- `make smoke-local`
- `make down-local`
- `make lint-react`
- `make test-react`

## Claude Review
- Reviewed locally with Claude Code CLI `2.1.168` using `claude-opus-4-8`.
- Result: no actionable/blocking findings.
- Non-blocking residual risk noted: the Autonomi minor-version bumps passed the local smoke path, but broader behavioral changes would require upstream changelog review or wider scenario coverage.
