### PR TITLE
Phase 5: Frontend god-component refactors and route splitting

### DIFF
--- a/apps/web/e2e/upload-playback.spec.ts
+++ b/apps/web/e2e/upload-playback.spec.ts
@@ -32,6 +32,8 @@ test("login, upload, approve, publish, and play an HLS segment", async ({ page }
   await page.getByRole("button", { name: "Upload" }).click();
   await page.locator('input[type="file"]').setInputFiles(fixturePath);
   await expect(page.getByText(/selected/i)).toBeVisible();
+  // Wait out the quote debounce so the submit guard sees a priced quote.
+  await expect(page.getByText(/ANT\b/)).toBeVisible({ timeout: 30_000 });
   await page.getByRole("button", { name: /^Upload / }).click();
 
   await expect(page).toHaveURL(/\/manage/);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { lazy, Suspense, useCallback, useState } from "react";
 import {
   BrowserRouter,
   Navigate,
@@ -12,9 +12,12 @@ import {
 import "./App.css";
 import DesktopSetupGate from "./components/DesktopSetupGate";
 import ErrorBoundary from "./components/ErrorBoundary";
-import Library from "./components/Library";
 import LoginPanel from "./components/LoginPanel";
-import UploadPanel from "./components/UploadPanel";
+
+// Route-split the heavy pages so the initial bundle (and the hls.js chunk
+// pulled in by the player) loads on demand.
+const Library = lazy(() => import("./components/Library"));
+const UploadPanel = lazy(() => import("./components/UploadPanel"));
 import { BRAND_IMAGE } from "./constants";
 import useAuth from "./hooks/useAuth";
 import type { AuthState } from "./types";
@@ -108,45 +111,58 @@ function AppRoutes() {
       </header>
 
       <main className="workspace-main">
-        <Routes>
-          <Route path="/" element={<Navigate to="/library" replace />} />
-          <Route path="/library" element={<Library key={`public-${refreshKey}`} />} />
-          <Route path="/library/:videoId" element={<Library key={`public-${refreshKey}`} />} />
-          <Route path="/videos/:videoId" element={<VideoDetailRedirect />} />
-          <Route
-            path="/manage"
-            element={
-              auth ? (
-                <Library key={`admin-${refreshKey}`} admin />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/manage/:videoId"
-            element={
-              auth ? (
-                <Library key={`admin-${refreshKey}`} admin />
-              ) : (
-                <Navigate to="/login" replace />
-              )
-            }
-          />
-          <Route
-            path="/upload"
-            element={
-              auth ? <UploadPanel onUploaded={handleUploaded} /> : <Navigate to="/login" replace />
-            }
-          />
-          <Route
-            path="/login"
-            element={
-              auth ? <Navigate to="/manage" replace /> : <LoginPanel onLogin={handleLogin} />
-            }
-          />
-          <Route path="*" element={<Navigate to="/library" replace />} />
-        </Routes>
+        <Suspense
+          fallback={
+            <div className="empty-state">
+              <span className="empty-icon" aria-hidden="true" />
+              <strong>Loading...</strong>
+            </div>
+          }
+        >
+          <Routes>
+            <Route path="/" element={<Navigate to="/library" replace />} />
+            <Route path="/library" element={<Library key={`public-${refreshKey}`} />} />
+            <Route path="/library/:videoId" element={<Library key={`public-${refreshKey}`} />} />
+            <Route path="/videos/:videoId" element={<VideoDetailRedirect />} />
+            <Route
+              path="/manage"
+              element={
+                auth ? (
+                  <Library key={`admin-${refreshKey}`} admin />
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/manage/:videoId"
+              element={
+                auth ? (
+                  <Library key={`admin-${refreshKey}`} admin />
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/upload"
+              element={
+                auth ? (
+                  <UploadPanel onUploaded={handleUploaded} />
+                ) : (
+                  <Navigate to="/login" replace />
+                )
+              }
+            />
+            <Route
+              path="/login"
+              element={
+                auth ? <Navigate to="/manage" replace /> : <LoginPanel onLogin={handleLogin} />
+              }
+            />
+            <Route path="*" element={<Navigate to="/library" replace />} />
+          </Routes>
+        </Suspense>
       </main>
     </div>
   );

--- a/apps/web/src/__tests__/testUtils.tsx
+++ b/apps/web/src/__tests__/testUtils.tsx
@@ -77,6 +77,20 @@ export function text(): string {
   return container.textContent;
 }
 
+/**
+ * Waits for the lazily-loaded upload page to render its file input. Call
+ * before installing fake timers: the first dynamic import needs real time.
+ */
+export async function findFileInput(): Promise<HTMLInputElement> {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    const input = container.querySelector('input[type="file"]');
+    if (input) return input as HTMLInputElement;
+    await flushPromises();
+    await act(() => new Promise((resolve) => setTimeout(resolve, 5)));
+  }
+  throw new Error("file input did not render");
+}
+
 export function findButton(label: string | RegExp): HTMLButtonElement {
   const matcher = label instanceof RegExp ? label : new RegExp(label, "i");
   const button = Array.from(container.querySelectorAll("button")).find((candidate) =>

--- a/apps/web/src/__tests__/upload.test.tsx
+++ b/apps/web/src/__tests__/upload.test.tsx
@@ -6,6 +6,7 @@ import {
   container,
   findButton,
   findCheckbox,
+  findFileInput,
   flushPromises,
   renderApp,
   setAuthenticatedCookies,
@@ -14,7 +15,6 @@ import {
 } from "./testUtils";
 
 test("shows an upload quote after local video metadata is available", async () => {
-  vi.useFakeTimers();
   setAuthenticatedCookies();
   setupGetRoutes();
 
@@ -80,7 +80,8 @@ test("shows an upload quote after local video metadata is available", async () =
   await renderApp();
   await click(findButton("Upload"));
 
-  const fileInput = container.querySelector('input[type="file"]');
+  const fileInput = await findFileInput();
+  vi.useFakeTimers();
   const file = new File(["fake video"], "launch.mp4", { type: "video/mp4" });
   await act(async () => {
     Object.defineProperty(fileInput, "files", { configurable: true, value: [file] });
@@ -101,7 +102,6 @@ test("shows an upload quote after local video metadata is available", async () =
 });
 
 test("sends original-source and auto-publish options with an upload", async () => {
-  vi.useFakeTimers();
   setAuthenticatedCookies();
   setupGetRoutes();
 
@@ -165,7 +165,8 @@ test("sends original-source and auto-publish options with an upload", async () =
   await renderApp();
   await click(findButton("Upload"));
 
-  const fileInput = container.querySelector('input[type="file"]');
+  const fileInput = await findFileInput();
+  vi.useFakeTimers();
   const file = new File(["original source"], "source.mp4", { type: "video/mp4" });
   expect(file.size).toBe(15);
   await act(async () => {
@@ -200,7 +201,6 @@ test("sends original-source and auto-publish options with an upload", async () =
 });
 
 test("shows quote and upload errors without clearing the selected source", async () => {
-  vi.useFakeTimers();
   setAuthenticatedCookies();
   setupGetRoutes();
 
@@ -255,7 +255,8 @@ test("shows quote and upload errors without clearing the selected source", async
   await renderApp();
   await click(findButton("Upload"));
 
-  const fileInput = container.querySelector('input[type="file"]');
+  const fileInput = await findFileInput();
+  vi.useFakeTimers();
   const file = new File(["source bytes"], "failure.mp4", { type: "video/mp4" });
   await act(async () => {
     Object.defineProperty(fileInput, "files", { configurable: true, value: [file] });

--- a/apps/web/src/__tests__/upload.test.tsx
+++ b/apps/web/src/__tests__/upload.test.tsx
@@ -3,7 +3,6 @@ import { vi } from "vitest";
 import {
   axios,
   click,
-  container,
   findButton,
   findCheckbox,
   findFileInput,

--- a/apps/web/src/components/Library.tsx
+++ b/apps/web/src/components/Library.tsx
@@ -1,21 +1,10 @@
 import { useCallback, useEffect, useState, type MouseEvent } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import {
-  approveVideoUpload,
-  deleteVideoRecord,
-  getAdminCatalogs,
-  getVideoDetails,
-  listVideos,
-  publishAdminCatalogs,
-  requestErrorMessage,
-  updateVideoPublication,
-  updateVideoVisibility,
-} from "../api/client";
-import type { AdminCatalogs, VideoDetail, VideoSummary, VisibilityUpdate } from "../types";
-import { isActiveStatus, statusLabel } from "../utils/status";
-import FinalQuotePanel from "./FinalQuotePanel";
-import VideoPlayer from "./VideoPlayer";
+import { useCatalogs, useLibraryData, useVideoActions, useVideoDetail } from "../hooks/useLibrary";
+import { statusLabel } from "../utils/status";
+import CatalogPanel from "./library/CatalogPanel";
+import VideoDetailPane from "./library/VideoDetailPane";
 
 interface LibraryProps {
   admin?: boolean;
@@ -30,114 +19,45 @@ export default function Library({ admin = false }: LibraryProps) {
   const navigate = useNavigate();
   const { videoId: routeVideoId } = useParams<{ videoId?: string }>();
   const detailBasePath = admin ? "/manage" : "/library";
-  const [videos, setVideos] = useState<VideoSummary[]>([]);
-  const [loading, setLoading] = useState(true);
   const [playing, setPlaying] = useState<PlayingState | null>(null);
-  const [detail, setDetail] = useState<VideoDetail | null>(null);
-  const [approving, setApproving] = useState<string | null>(null);
-  const [publishing, setPublishing] = useState<string | null>(null);
-  const [catalogs, setCatalogs] = useState<AdminCatalogs | null>(null);
-  const [catalogPublishing, setCatalogPublishing] = useState(false);
-  const [catalogCopied, setCatalogCopied] = useState("");
-  const [loadError, setLoadError] = useState("");
-  const [detailError, setDetailError] = useState("");
-  const [actionError, setActionError] = useState("");
-  const [catalogError, setCatalogError] = useState("");
-  const activeDetailId = detail?.id;
-  const activeDetailStatus = detail?.status;
 
-  const load = useCallback(async () => {
-    try {
-      const data = await listVideos({ admin });
-      setVideos(data);
-      setLoadError("");
-    } catch (err) {
-      setLoadError(requestErrorMessage(err, "Could not load the video catalog."));
-    } finally {
-      setLoading(false);
-    }
-  }, [admin]);
+  const { videos, setVideos, loading, loadError, load } = useLibraryData(admin);
+  const { detail, setDetail, detailError, loadDetail } = useVideoDetail(admin, routeVideoId);
+  const {
+    catalogs,
+    catalogPublishing,
+    catalogCopied,
+    catalogError,
+    loadCatalogs,
+    republishCatalogs,
+    copyAddress,
+  } = useCatalogs(admin);
 
-  const loadDetail = useCallback(
-    async (videoId: string) => {
-      setDetailError("");
-      setActionError("");
-      try {
-        const data = await getVideoDetails({ admin, videoId });
-        setDetail(data);
-      } catch (err) {
-        setDetailError(requestErrorMessage(err, "Could not load video details."));
+  const onDeleted = useCallback(
+    (videoId: string) => {
+      if (detail?.id === videoId) {
+        setDetail(null);
+        navigate(detailBasePath, { replace: true });
       }
+      setPlaying((prev) => (prev?.videoId === videoId ? null : prev));
     },
-    [admin],
+    [detail?.id, detailBasePath, navigate, setDetail],
   );
 
-  const loadCatalogs = useCallback(async () => {
-    if (!admin) return;
-    try {
-      const data = await getAdminCatalogs();
-      setCatalogs(data);
-      setCatalogError("");
-    } catch (err) {
-      setCatalogError(requestErrorMessage(err, "Could not load catalog addresses."));
-    }
-  }, [admin]);
+  const {
+    approving,
+    publishing,
+    actionError,
+    setActionError,
+    deleteVideo,
+    approveVideo,
+    updateVisibility,
+    updatePublication,
+  } = useVideoActions({ load, loadCatalogs, onDeleted, setDetail, setVideos });
 
   useEffect(() => {
-    load();
-  }, [load]);
-
-  useEffect(() => {
-    loadCatalogs();
-  }, [loadCatalogs]);
-
-  useEffect(() => {
-    if (!routeVideoId) {
-      setDetail(null);
-      return;
-    }
-
-    let active = true;
-    setDetailError("");
     setActionError("");
-    getVideoDetails({ admin, videoId: routeVideoId })
-      .then((data) => {
-        if (active) setDetail(data);
-      })
-      .catch((err) => {
-        if (active) {
-          setDetail(null);
-          setDetailError(requestErrorMessage(err, "Could not load video details."));
-        }
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [admin, routeVideoId]);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      if (videos.some((video) => isActiveStatus(video.status))) {
-        load();
-      }
-    }, 5000);
-    return () => clearInterval(interval);
-  }, [videos, load]);
-
-  useEffect(() => {
-    if (!activeDetailId || !isActiveStatus(activeDetailStatus)) return undefined;
-    const interval = setInterval(async () => {
-      try {
-        const data = await getVideoDetails({ admin, videoId: activeDetailId });
-        setDetail(data);
-        setDetailError("");
-      } catch (err) {
-        setDetailError(requestErrorMessage(err, "Could not refresh video details."));
-      }
-    }, 5000);
-    return () => clearInterval(interval);
-  }, [activeDetailId, activeDetailStatus, admin]);
+  }, [routeVideoId, setActionError]);
 
   const openDetail = async (videoId: string) => {
     if (routeVideoId === videoId && detail?.id === videoId) {
@@ -145,100 +65,16 @@ export default function Library({ admin = false }: LibraryProps) {
       return;
     }
     if (routeVideoId === videoId) {
+      setActionError("");
       await loadDetail(videoId);
       return;
     }
     navigate(`${detailBasePath}/${encodeURIComponent(videoId)}`);
   };
 
-  const deleteVideo = async (videoId: string, event: MouseEvent<HTMLButtonElement>) => {
+  const handleDelete = (videoId: string) => (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    if (!window.confirm("Delete this video record and remove it from the network catalog?")) return;
-    setActionError("");
-    try {
-      await deleteVideoRecord(videoId);
-      setVideos((prev) => prev.filter((video) => video.id !== videoId));
-      await loadCatalogs();
-      if (detail?.id === videoId) {
-        setDetail(null);
-        navigate(detailBasePath, { replace: true });
-      }
-      if (playing?.videoId === videoId) setPlaying(null);
-    } catch (err) {
-      setActionError(requestErrorMessage(err, "Delete failed."));
-    }
-  };
-
-  const approveVideo = async (videoId: string) => {
-    setApproving(videoId);
-    setActionError("");
-    try {
-      const data = await approveVideoUpload(videoId);
-      setDetail(data);
-      await load();
-      await loadCatalogs();
-    } catch (err) {
-      const message = requestErrorMessage(err, "Approval failed.");
-      setActionError(message);
-      window.alert(message);
-    } finally {
-      setApproving(null);
-    }
-  };
-
-  const updateVisibility = async (videoId: string, next: VisibilityUpdate) => {
-    setActionError("");
-    try {
-      const data = await updateVideoVisibility(videoId, next);
-      setDetail(data);
-      setVideos((prev) =>
-        prev.map((video) => (video.id === videoId ? { ...video, ...data } : video)),
-      );
-      await loadCatalogs();
-    } catch (err) {
-      setActionError(requestErrorMessage(err, "Visibility update failed."));
-    }
-  };
-
-  const updatePublication = async (videoId: string, isPublic: boolean) => {
-    setPublishing(videoId);
-    setActionError("");
-    try {
-      const data = await updateVideoPublication(videoId, isPublic);
-      setDetail(data);
-      setVideos((prev) =>
-        prev.map((video) => (video.id === videoId ? { ...video, ...data } : video)),
-      );
-      await loadCatalogs();
-    } catch (err) {
-      setActionError(requestErrorMessage(err, isPublic ? "Publish failed." : "Unpublish failed."));
-    } finally {
-      setPublishing(null);
-    }
-  };
-
-  const republishCatalogs = async () => {
-    setCatalogPublishing(true);
-    setCatalogError("");
-    setCatalogCopied("");
-    try {
-      const data = await publishAdminCatalogs();
-      setCatalogs(data);
-    } catch (err) {
-      setCatalogError(requestErrorMessage(err, "Catalog publish failed."));
-    } finally {
-      setCatalogPublishing(false);
-    }
-  };
-
-  const copyAddress = async (label: string, address?: string | null) => {
-    if (!address) return;
-    try {
-      await navigator.clipboard.writeText(address);
-      setCatalogCopied(label);
-    } catch {
-      setCatalogError("Could not copy the catalog address.");
-    }
+    deleteVideo(videoId);
   };
 
   if (loading) {
@@ -292,39 +128,13 @@ export default function Library({ admin = false }: LibraryProps) {
       {catalogError && <div className="error-box">{catalogError}</div>}
 
       {admin && (
-        <div className="catalog-address-panel">
-          <div className="catalog-address-head">
-            <div>
-              <strong>Portable catalogs</strong>
-              <span>
-                Published {catalogs?.published_catalog?.videos.length ?? 0} / all{" "}
-                {catalogs?.all_catalog?.videos.length ?? 0}
-              </span>
-            </div>
-            <button
-              type="button"
-              className="secondary-action"
-              disabled={catalogPublishing}
-              onClick={republishCatalogs}
-            >
-              {catalogPublishing ? "Publishing..." : "Republish"}
-            </button>
-          </div>
-          <div className="catalog-address-grid">
-            <CatalogAddress
-              label="Published"
-              address={catalogs?.published_catalog_address}
-              copied={catalogCopied === "published"}
-              onCopy={() => copyAddress("published", catalogs?.published_catalog_address)}
-            />
-            <CatalogAddress
-              label="All"
-              address={catalogs?.all_catalog_address}
-              copied={catalogCopied === "all"}
-              onCopy={() => copyAddress("all", catalogs?.all_catalog_address)}
-            />
-          </div>
-        </div>
+        <CatalogPanel
+          catalogs={catalogs}
+          catalogPublishing={catalogPublishing}
+          catalogCopied={catalogCopied}
+          onCopy={copyAddress}
+          onRepublish={republishCatalogs}
+        />
       )}
 
       <div className="video-list">
@@ -352,139 +162,24 @@ export default function Library({ admin = false }: LibraryProps) {
             </button>
 
             {detail?.id === video.id && (
-              <div className="video-detail">
-                {admin && detail.status === "awaiting_approval" ? (
-                  <FinalQuotePanel
-                    quote={detail.final_quote}
-                    expiresAt={detail.approval_expires_at}
-                    approving={approving === video.id}
-                    onApprove={() => approveVideo(video.id)}
-                  />
-                ) : admin && detail.status === "uploading" ? (
-                  <p className="muted">
-                    Uploading approved segments and publishing the network manifest...
-                  </p>
-                ) : admin && (detail.status === "processing" || detail.status === "pending") ? (
-                  <p className="muted">Processing renditions and preparing the final quote...</p>
-                ) : admin && (detail.status === "error" || detail.status === "expired") ? (
-                  <p className="muted">
-                    {detail.error_message || "This video could not be completed."}
-                  </p>
-                ) : detail.variants.length === 0 ? (
-                  <p className="muted">No variants available.</p>
-                ) : (
-                  <>
-                    {(() => {
-                      const selectedVariant =
-                        detail.variants.find(
-                          (variant) =>
-                            playing?.videoId === video.id &&
-                            playing?.resolution === variant.resolution,
-                        ) || detail.variants[0];
-
-                      return (
-                        <VideoPlayer
-                          videoId={video.id}
-                          manifestAddress={admin ? detail.manifest_address : null}
-                          variants={detail.variants}
-                          resolution={selectedVariant.resolution}
-                          onResolutionChange={(nextResolution) =>
-                            setPlaying({
-                              videoId: video.id,
-                              resolution: nextResolution,
-                            })
-                          }
-                        />
-                      );
-                    })()}
-                  </>
-                )}
-                {admin && (
-                  <>
-                    {detail.status === "ready" && (
-                      <div className="publication-panel">
-                        <button
-                          type="button"
-                          className={
-                            detail.is_public ? "secondary-action" : "primary-action compact-action"
-                          }
-                          disabled={publishing === video.id}
-                          onClick={() => updatePublication(video.id, !detail.is_public)}
-                        >
-                          {publishing === video.id
-                            ? "Updating..."
-                            : detail.is_public
-                              ? "Unpublish"
-                              : "Publish"}
-                        </button>
-                        <span className={`status ${detail.is_public ? "public" : "private"}`}>
-                          {detail.is_public ? "public" : "hidden"}
-                        </span>
-                      </div>
-                    )}
-                    <div className="visibility-panel">
-                      <label>
-                        <input
-                          type="checkbox"
-                          checked={!!detail.show_manifest_address}
-                          onChange={(event) =>
-                            updateVisibility(video.id, {
-                              show_original_filename: false,
-                              show_manifest_address: event.target.checked,
-                            })
-                          }
-                        />
-                        <span>Publish manifest address</span>
-                      </label>
-                    </div>
-                  </>
-                )}
-                {(admin || detail.manifest_address) && (
-                  <div className="detail-footer">
-                    <div className="detail-addresses">
-                      <code>{detail.manifest_address || "Manifest hidden or pending"}</code>
-                      {admin && detail.original_file_address && (
-                        <code>Original source: {detail.original_file_address}</code>
-                      )}
-                    </div>
-                    {admin && (
-                      <button
-                        type="button"
-                        className="danger-action"
-                        onClick={(event) => deleteVideo(video.id, event)}
-                      >
-                        Delete
-                      </button>
-                    )}
-                  </div>
-                )}
-              </div>
+              <VideoDetailPane
+                admin={admin}
+                detail={detail}
+                approving={approving === video.id}
+                publishing={publishing === video.id}
+                selectedResolution={playing?.videoId === video.id ? playing.resolution : null}
+                onApprove={() => approveVideo(video.id)}
+                onDelete={handleDelete(video.id)}
+                onResolutionChange={(nextResolution) =>
+                  setPlaying({ videoId: video.id, resolution: nextResolution })
+                }
+                onUpdatePublication={(isPublic) => updatePublication(video.id, isPublic)}
+                onUpdateVisibility={(next) => updateVisibility(video.id, next)}
+              />
             )}
           </article>
         ))}
       </div>
     </section>
-  );
-}
-
-function CatalogAddress({
-  address,
-  copied,
-  label,
-  onCopy,
-}: {
-  address?: string | null;
-  copied: boolean;
-  label: string;
-  onCopy: () => void;
-}) {
-  return (
-    <div className="catalog-address-row">
-      <span>{label}</span>
-      <code>{address || "Not published yet"}</code>
-      <button type="button" className="secondary-action" disabled={!address} onClick={onCopy}>
-        {copied ? "Copied" : "Copy"}
-      </button>
-    </div>
   );
 }

--- a/apps/web/src/components/UploadPanel.tsx
+++ b/apps/web/src/components/UploadPanel.tsx
@@ -1,276 +1,79 @@
-import { useCallback, useEffect, useRef, useState, type DragEvent, type FormEvent } from "react";
+import { useCallback, useRef, type FormEvent } from "react";
 
 import {
-  isRequestCanceled,
-  requestErrorMessage,
-  requestUploadQuote,
-  uploadVideo,
-} from "../api/client";
-import { RESOLUTION_OPTIONS } from "../constants";
-import type {
-  EncodeSettings,
-  SourceVideoMeta,
-  UploadQuote,
-  UploadQuoteRequest,
-  VideoSummary,
-} from "../types";
-import { formatAttoTokens, formatBytes, formatWei } from "../utils/format";
-import {
-  classifyResolution,
-  optionFitsSource,
-  orderedSelection,
-  resolutionByValue,
-  suggestedSelection,
-  targetDimensionsForMeta,
-} from "../utils/resolutions";
-
-interface QuoteState {
-  data: UploadQuote | null;
-  error: string;
-  loading: boolean;
-}
+  useUploadForm,
+  useUploadQuote,
+  useUploadSubmit,
+  type VideoCodec,
+} from "../hooks/useUploadWorkflow";
+import type { VideoSummary } from "../types";
+import { resolutionByValue } from "../utils/resolutions";
+import EncodeSettingsFields from "./upload/EncodeSettingsFields";
+import FileDropZone from "./upload/FileDropZone";
+import UploadQuoteSummary from "./upload/UploadQuoteSummary";
 
 interface UploadPanelProps {
   onUploaded: (video: VideoSummary) => void;
 }
 
-type VideoCodec = EncodeSettings["video_codec"];
-
-const DEFAULT_AUDIO_BITRATE_KBPS = 320;
-
-function defaultVideoBitrate(optionKbps: number, codec: VideoCodec): number {
-  if (codec === "hevc") return Math.max(64, Math.round((optionKbps * 0.7) / 50) * 50);
-  return optionKbps;
-}
-
-function defaultVideoBitrates(codec: VideoCodec): Record<string, number> {
-  return Object.fromEntries(
-    RESOLUTION_OPTIONS.map((option) => [
-      option.value,
-      defaultVideoBitrate(option.defaultVideoBitrateKbps, codec),
-    ]),
-  );
-}
-
-function buildEncodeSettings(
-  resolutions: string[],
-  videoCodec: VideoCodec,
-  videoBitrates: Record<string, number>,
-  audioBitrateKbps: number,
-): EncodeSettings {
-  const video_bitrate_overrides = Object.fromEntries(
-    resolutions.map((resolution) => [
-      resolution,
-      Math.max(64, Math.round(videoBitrates[resolution] || 0)),
-    ]),
-  );
-  return {
-    video_codec: videoCodec,
-    audio_bitrate_kbps: Math.max(32, Math.round(audioBitrateKbps || DEFAULT_AUDIO_BITRATE_KBPS)),
-    video_bitrate_overrides,
-  };
-}
-
 export default function UploadPanel({ onUploaded }: UploadPanelProps) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const [file, setFile] = useState<File | null>(null);
-  const [title, setTitle] = useState("");
-  const [desc, setDesc] = useState("");
-  const [showManifestAddress, setShowManifestAddress] = useState(false);
-  const [uploadOriginal, setUploadOriginal] = useState(false);
-  const [publishWhenReady, setPublishWhenReady] = useState(false);
-  const [selected, setSelected] = useState<string[]>(["720p"]);
-  const [videoCodec, setVideoCodec] = useState<VideoCodec>("h264");
-  const [audioBitrateKbps, setAudioBitrateKbps] = useState(DEFAULT_AUDIO_BITRATE_KBPS);
-  const [videoBitrates, setVideoBitrates] = useState<Record<string, number>>(() =>
-    defaultVideoBitrates("h264"),
+  const form = useUploadForm();
+  const { quote, resetQuote } = useUploadQuote(form);
+
+  const handleUploadSuccess = useCallback(
+    (video: VideoSummary) => {
+      form.reset();
+      resetQuote();
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      onUploaded(video);
+    },
+    [form, onUploaded, resetQuote],
   );
-  const [uploading, setUploading] = useState(false);
-  const [error, setError] = useState("");
-  const [progress, setProgress] = useState(0);
-  const [dragging, setDragging] = useState(false);
-  const [meta, setMeta] = useState<SourceVideoMeta | null>(null);
-  const [quote, setQuote] = useState<QuoteState>({ loading: false, error: "", data: null });
 
-  const currentProfile = classifyResolution(meta?.width, meta?.height);
+  const { uploading, error, setError, progress, submit } = useUploadSubmit({
+    form,
+    quote,
+    onSuccess: handleUploadSuccess,
+  });
 
-  const inspectFile = useCallback((nextFile?: File) => {
+  const handleFile = (nextFile?: File) => {
     if (!nextFile) return;
     if (!nextFile.type.startsWith("video/")) {
       setError("Please choose a video file.");
       return;
     }
-
     setError("");
-    setFile(nextFile);
-    setQuote({ loading: false, error: "", data: null });
-    setTitle((current) => current || nextFile.name.replace(/\.[^.]+$/, ""));
-    setMeta({ loading: true, width: null, height: null, duration: null });
+    resetQuote();
+    form.inspectFile(nextFile);
+  };
 
-    const objectUrl = URL.createObjectURL(nextFile);
-    const video = document.createElement("video");
-    video.preload = "metadata";
-    video.onloadedmetadata = () => {
-      const nextMeta = {
-        loading: false,
-        width: video.videoWidth,
-        height: video.videoHeight,
-        duration: video.duration,
-        size: nextFile.size,
-      };
-      setMeta(nextMeta);
-      setSelected(suggestedSelection(nextMeta));
-      URL.revokeObjectURL(objectUrl);
-    };
-    video.onerror = () => {
-      setMeta({ loading: false, width: null, height: null, duration: null, size: nextFile.size });
-      setSelected(["720p"]);
-      URL.revokeObjectURL(objectUrl);
-    };
-    video.src = objectUrl;
-  }, []);
+  const handleCodecChange = (codec: VideoCodec) => {
+    form.changeCodec(codec);
+    resetQuote();
+  };
 
-  useEffect(() => {
-    const duration = meta?.duration;
-    if (!file || !duration || !selected.length) {
-      setQuote({ loading: false, error: "", data: null });
-      return undefined;
-    }
+  const handleAudioBitrateChange = (kbps: number) => {
+    form.setAudioBitrateKbps(kbps);
+    resetQuote();
+  };
 
-    const controller = new AbortController();
-    const timer = setTimeout(async () => {
-      const resolutions = orderedSelection(selected);
-      setQuote({ loading: true, error: "", data: null });
-      try {
-        const encodeSettings = buildEncodeSettings(
-          resolutions,
-          videoCodec,
-          videoBitrates,
-          audioBitrateKbps,
-        );
-        const quoteRequest: UploadQuoteRequest = {
-          duration_seconds: duration,
-          encode_settings: encodeSettings,
-          resolutions,
-          source_width: meta.width,
-          source_height: meta.height,
-        };
-        if (uploadOriginal) {
-          quoteRequest.upload_original = true;
-          quoteRequest.source_size_bytes = file.size;
-        }
-        const data = await requestUploadQuote(quoteRequest, controller.signal);
-        setQuote({ loading: false, error: "", data });
-      } catch (err) {
-        if (isRequestCanceled(err)) return;
-        setQuote({
-          loading: false,
-          error: requestErrorMessage(err, "Could not get upload price quote"),
-          data: null,
-        });
-      }
-    }, 250);
+  const handleVideoBitrateChange = (resolution: string, kbps: number) => {
+    form.setVideoBitrate(resolution, kbps);
+    resetQuote();
+  };
 
-    return () => {
-      controller.abort();
-      clearTimeout(timer);
-    };
-  }, [
-    audioBitrateKbps,
-    file,
-    meta?.duration,
-    meta?.width,
-    meta?.height,
-    selected,
-    uploadOriginal,
-    videoBitrates,
-    videoCodec,
-  ]);
+  const handleUploadOriginalChange = (checked: boolean) => {
+    form.setUploadOriginal(checked);
+    resetQuote();
+  };
 
-  const onDrop = (event: DragEvent<HTMLButtonElement>) => {
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setDragging(false);
-    inspectFile(event.dataTransfer.files?.[0]);
+    submit();
   };
 
-  const toggleRes = (resolution: string) => {
-    setSelected((prev) =>
-      prev.includes(resolution)
-        ? prev.filter((value) => value !== resolution)
-        : [...prev, resolution],
-    );
-  };
-
-  const selectCurrentOnly = () => {
-    if (currentProfile) setSelected([currentProfile.value]);
-  };
-
-  const selectAdaptive = () => {
-    setSelected(suggestedSelection(meta));
-  };
-
-  const submit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!file) return setError("Drop or choose a video file first.");
-    if (!title.trim()) return setError("Please enter a title.");
-    if (!selected.length) return setError("Select at least one resolution.");
-    if (meta?.duration && !quote.data) {
-      return setError("Waiting for an upload price quote before starting.");
-    }
-
-    setError("");
-    setUploading(true);
-    setProgress(0);
-
-    const resolutionsToUpload = orderedSelection(selected);
-
-    const fd = new FormData();
-    const encodeSettings = buildEncodeSettings(
-      resolutionsToUpload,
-      videoCodec,
-      videoBitrates,
-      audioBitrateKbps,
-    );
-    fd.append("file", file);
-    fd.append("title", title.trim());
-    fd.append("description", desc.trim());
-    fd.append("resolutions", resolutionsToUpload.join(","));
-    fd.append("show_original_filename", "false");
-    fd.append("show_manifest_address", showManifestAddress ? "true" : "false");
-    fd.append("upload_original", uploadOriginal ? "true" : "false");
-    fd.append("publish_when_ready", publishWhenReady ? "true" : "false");
-    fd.append("video_codec", encodeSettings.video_codec);
-    fd.append("audio_bitrate_kbps", String(encodeSettings.audio_bitrate_kbps));
-    fd.append("video_bitrate_overrides", JSON.stringify(encodeSettings.video_bitrate_overrides));
-
-    try {
-      const data = await uploadVideo(fd, (progressEvent) => {
-        if (progressEvent.total) {
-          setProgress(Math.round((progressEvent.loaded / progressEvent.total) * 100));
-        }
-      });
-      setFile(null);
-      setTitle("");
-      setDesc("");
-      setShowManifestAddress(false);
-      setUploadOriginal(false);
-      setPublishWhenReady(false);
-      setSelected(["720p"]);
-      setVideoCodec("h264");
-      setAudioBitrateKbps(DEFAULT_AUDIO_BITRATE_KBPS);
-      setVideoBitrates(defaultVideoBitrates("h264"));
-      setMeta(null);
-      setQuote({ loading: false, error: "", data: null });
-      setProgress(0);
-      if (fileInputRef.current) fileInputRef.current.value = "";
-      onUploaded(data);
-    } catch (err) {
-      setError(requestErrorMessage(err, "Upload failed"));
-    } finally {
-      setUploading(false);
-    }
-    return undefined;
-  };
+  const { file, meta, currentProfile, selected } = form;
 
   return (
     <section className="upload-card">
@@ -286,34 +89,13 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
         <div className="network-pill">Local devnet ready</div>
       </div>
 
-      <form onSubmit={submit}>
-        <button
-          type="button"
-          className={`dropzone ${dragging ? "is-dragging" : ""}`}
-          onClick={() => fileInputRef.current?.click()}
-          onDragEnter={(event) => {
-            event.preventDefault();
-            setDragging(true);
-          }}
-          onDragOver={(event) => event.preventDefault()}
-          onDragLeave={() => setDragging(false)}
-          onDrop={onDrop}
-          disabled={uploading}
-        >
-          <input
-            ref={fileInputRef}
-            className="hidden-input"
-            type="file"
-            accept="video/*"
-            onChange={(event) => inspectFile(event.target.files?.[0])}
-            disabled={uploading}
-          />
-          <span className="drop-icon">+</span>
-          <span className="drop-title">{file ? file.name : "Drag and drop a video file"}</span>
-          <span className="drop-subtitle">
-            {file ? `${formatBytes(file.size)} selected` : "or click to browse from your machine"}
-          </span>
-        </button>
+      <form onSubmit={onSubmit}>
+        <FileDropZone
+          file={file}
+          fileInputRef={fileInputRef}
+          onFile={handleFile}
+          uploading={uploading}
+        />
 
         {file && (
           <div className="source-panel">
@@ -342,16 +124,16 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
           <label>
             <span>Title</span>
             <input
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
+              value={form.title}
+              onChange={(event) => form.setTitle(event.target.value)}
               disabled={uploading}
             />
           </label>
           <label>
             <span>Description</span>
             <input
-              value={desc}
-              onChange={(event) => setDesc(event.target.value)}
+              value={form.desc}
+              onChange={(event) => form.setDesc(event.target.value)}
               disabled={uploading}
             />
           </label>
@@ -361,8 +143,8 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
           <label>
             <input
               type="checkbox"
-              checked={showManifestAddress}
-              onChange={(event) => setShowManifestAddress(event.target.checked)}
+              checked={form.showManifestAddress}
+              onChange={(event) => form.setShowManifestAddress(event.target.checked)}
               disabled={uploading}
             />
             <span>Publish manifest address</span>
@@ -370,11 +152,8 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
           <label>
             <input
               type="checkbox"
-              checked={uploadOriginal}
-              onChange={(event) => {
-                setUploadOriginal(event.target.checked);
-                setQuote({ loading: false, error: "", data: null });
-              }}
+              checked={form.uploadOriginal}
+              onChange={(event) => handleUploadOriginalChange(event.target.checked)}
               disabled={uploading}
             />
             <span>Upload original source file</span>
@@ -382,166 +161,32 @@ export default function UploadPanel({ onUploaded }: UploadPanelProps) {
           <label>
             <input
               type="checkbox"
-              checked={publishWhenReady}
-              onChange={(event) => setPublishWhenReady(event.target.checked)}
+              checked={form.publishWhenReady}
+              onChange={(event) => form.setPublishWhenReady(event.target.checked)}
               disabled={uploading}
             />
             <span>Publish automatically when ready</span>
           </label>
         </div>
 
-        <div className="encoding-panel">
-          <div className="encoding-row">
-            <label>
-              <span>Video codec</span>
-              <select
-                value={videoCodec}
-                onChange={(event) => {
-                  const nextCodec = event.target.value as VideoCodec;
-                  const previousCodec = videoCodec;
-                  setVideoCodec(nextCodec);
-                  setVideoBitrates((current) => {
-                    const previousDefaults = defaultVideoBitrates(previousCodec);
-                    const nextDefaults = defaultVideoBitrates(nextCodec);
-                    return Object.fromEntries(
-                      RESOLUTION_OPTIONS.map((option) => {
-                        const currentValue = current[option.value];
-                        const nextValue =
-                          currentValue === previousDefaults[option.value]
-                            ? nextDefaults[option.value]
-                            : (currentValue ?? nextDefaults[option.value]);
-                        return [option.value, nextValue];
-                      }),
-                    );
-                  });
-                  setQuote({ loading: false, error: "", data: null });
-                }}
-                disabled={uploading}
-              >
-                <option value="h264">H.264</option>
-                <option value="hevc">HEVC / H.265</option>
-              </select>
-            </label>
-            <label>
-              <span>Audio bitrate</span>
-              <input
-                type="number"
-                min={32}
-                max={1024}
-                step={32}
-                value={audioBitrateKbps}
-                onChange={(event) => {
-                  setAudioBitrateKbps(Number(event.target.value));
-                  setQuote({ loading: false, error: "", data: null });
-                }}
-                disabled={uploading}
-              />
-            </label>
-          </div>
-          <div className="bitrate-grid">
-            {orderedSelection(selected).map((resolution) => {
-              const option = resolutionByValue(resolution);
-              return (
-                <label key={resolution}>
-                  <span>{option?.label || resolution}</span>
-                  <input
-                    type="number"
-                    min={64}
-                    max={200000}
-                    step={1}
-                    value={videoBitrates[resolution] || 0}
-                    onChange={(event) => {
-                      const nextValue = Number(event.target.value);
-                      setVideoBitrates((current) => ({
-                        ...current,
-                        [resolution]: nextValue,
-                      }));
-                      setQuote({ loading: false, error: "", data: null });
-                    }}
-                    disabled={uploading}
-                  />
-                </label>
-              );
-            })}
-          </div>
-        </div>
+        <EncodeSettingsFields
+          file={file}
+          meta={meta}
+          currentProfile={currentProfile}
+          selected={selected}
+          videoCodec={form.videoCodec}
+          audioBitrateKbps={form.audioBitrateKbps}
+          videoBitrates={form.videoBitrates}
+          uploading={uploading}
+          onCodecChange={handleCodecChange}
+          onAudioBitrateChange={handleAudioBitrateChange}
+          onVideoBitrateChange={handleVideoBitrateChange}
+          onToggleRes={form.toggleRes}
+          onSelectCurrentOnly={form.selectCurrentOnly}
+          onSelectAdaptive={form.selectAdaptive}
+        />
 
-        <div className="resolution-toolbar">
-          <div>
-            <span className="meta-label">Renditions to create</span>
-            <p>Higher-than-source options are dimmed to avoid accidental upscales.</p>
-          </div>
-          <div className="quick-actions">
-            <button
-              type="button"
-              onClick={selectCurrentOnly}
-              disabled={!currentProfile || uploading}
-            >
-              Current only
-            </button>
-            <button type="button" onClick={selectAdaptive} disabled={!file || uploading}>
-              Current + lower
-            </button>
-          </div>
-        </div>
-
-        <div className="resolution-grid">
-          {RESOLUTION_OPTIONS.map((option) => {
-            const isCurrent = currentProfile?.value === option.value;
-            const disabledBySource = !!file && !optionFitsSource(option, meta);
-            const targetDimensions = targetDimensionsForMeta(option, meta);
-            return (
-              <button
-                key={option.value}
-                type="button"
-                className={`resolution-card ${selected.includes(option.value) ? "selected" : ""}`}
-                onClick={() => !disabledBySource && toggleRes(option.value)}
-                disabled={uploading || disabledBySource}
-              >
-                <span className="resolution-label">{option.label}</span>
-                <span>
-                  {targetDimensions.width} x {targetDimensions.height}
-                </span>
-                <span>
-                  {option.bitrate} · {option.note}
-                </span>
-                {isCurrent && <strong>Current source profile</strong>}
-              </button>
-            );
-          })}
-        </div>
-
-        {file && (
-          <div className="quote-panel">
-            <div className="quote-main">
-              <span className="meta-label">Upload price quote</span>
-              {quote.loading && <strong>Quoting Autonomi storage...</strong>}
-              {!quote.loading && quote.data && (
-                <strong>{formatAttoTokens(quote.data.storage_cost_atto)}</strong>
-              )}
-              {!quote.loading && !quote.data && (
-                <strong>{quote.error ? "Quote unavailable" : "Waiting for video duration"}</strong>
-              )}
-              <p>
-                {quote.data
-                  ? `${formatBytes(quote.data.estimated_bytes)} across ${quote.data.segment_count} HLS segments${quote.data.original_file ? ", original file," : ""} and metadata`
-                  : quote.error || "The estimate refreshes when renditions change."}
-              </p>
-            </div>
-            {quote.data && (
-              <div className="quote-breakdown">
-                <span>{formatWei(quote.data.estimated_gas_cost_wei)}</span>
-                <span>{quote.data.payment_mode} payment mode</span>
-                {quote.data.original_file && (
-                  <span>
-                    {formatBytes(quote.data.original_file.estimated_bytes)} original source
-                  </span>
-                )}
-                {quote.data.sampled && <span>large segment estimate sampled</span>}
-              </div>
-            )}
-          </div>
-        )}
+        {file && <UploadQuoteSummary quote={quote} />}
 
         {uploading && (
           <div className="upload-progress">

--- a/apps/web/src/components/VideoPlayer.tsx
+++ b/apps/web/src/components/VideoPlayer.tsx
@@ -1,29 +1,10 @@
-import { useCallback, useEffect, useRef, useState, type FocusEvent } from "react";
-import type Hls from "hls.js";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-import { PLAYER_CONTROLS_IDLE_MS, RESUME_DURATION_TOLERANCE_SECONDS } from "../constants";
+import { useControlsVisibility } from "../hooks/useControlsVisibility";
+import { useHlsPlayer } from "../hooks/useHlsPlayer";
 import { STREAM_BASE_URL } from "../runtimeConfig";
 import type { VideoVariant } from "../types";
-import { variantDisplayLabel } from "../utils/resolutions";
-
-const HLS_RETRY_CONFIG = {
-  fragLoadingMaxRetry: 4,
-  fragLoadingMaxRetryTimeout: 8_000,
-  fragLoadingRetryDelay: 500,
-  levelLoadingMaxRetry: 4,
-  levelLoadingMaxRetryTimeout: 8_000,
-  levelLoadingRetryDelay: 500,
-  manifestLoadingMaxRetry: 4,
-  manifestLoadingMaxRetryTimeout: 8_000,
-  manifestLoadingRetryDelay: 500,
-};
-const HLS_FATAL_RECOVERY_ATTEMPTS = 1;
-const MEDIA_HAVE_FUTURE_DATA = 3;
-
-interface PlaybackState {
-  currentTime: number;
-  shouldResume: boolean;
-}
+import QualityMenu from "./player/QualityMenu";
 
 interface VideoPlayerProps {
   manifestAddress?: string | null;
@@ -41,61 +22,23 @@ export default function VideoPlayer({
   onResolutionChange,
 }: VideoPlayerProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  const hlsRef = useRef<Hls | null>(null);
-  const controlsIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const playbackStateRef = useRef<PlaybackState>({ currentTime: 0, shouldResume: false });
-  const playbackIntentRef = useRef(false);
   const [qualityOpen, setQualityOpen] = useState(false);
-  const [controlsActive, setControlsActive] = useState(true);
-  const [playbackError, setPlaybackError] = useState("");
   const streamBase = manifestAddress
     ? `${STREAM_BASE_URL}/manifest/${manifestAddress}`
     : `${STREAM_BASE_URL}/${videoId}`;
   const src = `${streamBase}/${resolution}/playlist.m3u8`;
-  const selectedLabel = variantDisplayLabel(resolution);
 
-  const clearControlsIdleTimer = useCallback(() => {
-    if (controlsIdleTimerRef.current) {
-      clearTimeout(controlsIdleTimerRef.current);
-      controlsIdleTimerRef.current = null;
-    }
-  }, []);
+  const { playbackError, capturePlaybackState, playbackIntentRef } = useHlsPlayer(videoRef, src);
 
-  const hideControls = useCallback(() => {
-    clearControlsIdleTimer();
-    setQualityOpen(false);
-    setControlsActive(false);
-  }, [clearControlsIdleTimer]);
-
-  const scheduleControlsIdleHide = useCallback(() => {
-    clearControlsIdleTimer();
-    const video = videoRef.current;
-    if (!video || video.paused || video.ended) return;
-
-    controlsIdleTimerRef.current = setTimeout(() => {
-      setQualityOpen(false);
-      setControlsActive(false);
-      controlsIdleTimerRef.current = null;
-    }, PLAYER_CONTROLS_IDLE_MS);
-  }, [clearControlsIdleTimer]);
-
-  const showControls = useCallback(() => {
-    setControlsActive(true);
-    scheduleControlsIdleHide();
-  }, [scheduleControlsIdleHide]);
-
-  const capturePlaybackStateFromVideo = useCallback((video: HTMLVideoElement) => {
-    playbackStateRef.current = {
-      currentTime: Number.isFinite(video.currentTime) ? video.currentTime : 0,
-      shouldResume: playbackIntentRef.current || (!video.paused && !video.ended),
-    };
-  }, []);
-
-  const capturePlaybackState = useCallback(() => {
-    const video = videoRef.current;
-    if (!video) return;
-    capturePlaybackStateFromVideo(video);
-  }, [capturePlaybackStateFromVideo]);
+  const closeQualityMenu = useCallback(() => setQualityOpen(false), []);
+  const {
+    controlsActive,
+    setControlsActive,
+    showControls,
+    hideControls,
+    scheduleControlsIdleHide,
+    clearControlsIdleTimer,
+  } = useControlsVisibility(videoRef, closeQualityMenu);
 
   const handleResolutionChange = useCallback(
     (nextResolution: string) => {
@@ -104,295 +47,6 @@ export default function VideoPlayer({
     },
     [capturePlaybackState, onResolutionChange],
   );
-
-  useEffect(() => {
-    const video = videoRef.current;
-    if (!video) return undefined;
-
-    setPlaybackError("");
-    let active = true;
-    let cleanupPlayback = () => {};
-    const { currentTime: resumeAt, shouldResume } = playbackStateRef.current;
-    let pendingResumeAt = resumeAt;
-    let restorePending = resumeAt > 0;
-    let hlsManifestParsed = false;
-    let resumedAfterRestore = false;
-    let suppressNextHlsSeekSync = false;
-    let nativeSeekRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
-    let nativeSeekResumeAt = 0;
-    let nativeSeekShouldResume = false;
-    const readCurrentTime = () => (Number.isFinite(video.currentTime) ? video.currentTime : 0);
-    const seekVideoTo = (targetTime: number) => {
-      if (targetTime <= 0) return;
-
-      const duration = video.duration;
-      if (Number.isFinite(duration) && duration <= targetTime + RESUME_DURATION_TOLERANCE_SECONDS) {
-        return;
-      }
-
-      if (Math.abs(readCurrentTime() - targetTime) <= RESUME_DURATION_TOLERANCE_SECONDS) {
-        return;
-      }
-
-      try {
-        suppressNextHlsSeekSync = true;
-        video.currentTime = targetTime;
-      } catch {
-        suppressNextHlsSeekSync = false;
-        // MediaSource can briefly reject seeks while hls.js is rebuilding buffers.
-      }
-    };
-    const clearNativeSeekRecoveryTimer = () => {
-      if (nativeSeekRecoveryTimer) {
-        clearTimeout(nativeSeekRecoveryTimer);
-        nativeSeekRecoveryTimer = null;
-      }
-    };
-    const wantsPlayback = () => playbackIntentRef.current || (!video.paused && !video.ended);
-    const requestPlayback = () => {
-      playbackIntentRef.current = true;
-      video.play().catch(() => {});
-    };
-    const scheduleNativeSeekRecovery = () => {
-      clearNativeSeekRecoveryTimer();
-      if (!nativeSeekShouldResume) return;
-
-      nativeSeekRecoveryTimer = setTimeout(() => {
-        nativeSeekRecoveryTimer = null;
-        if (!active || !nativeSeekShouldResume || video.ended) return;
-
-        if (video.paused || video.readyState < MEDIA_HAVE_FUTURE_DATA) {
-          try {
-            if (
-              Math.abs(readCurrentTime() - nativeSeekResumeAt) > RESUME_DURATION_TOLERANCE_SECONDS
-            ) {
-              video.currentTime = nativeSeekResumeAt;
-            }
-          } catch {
-            // Safari can reject seeks while native HLS is swapping internal buffers.
-          }
-          requestPlayback();
-          scheduleNativeSeekRecovery();
-        }
-      }, 750);
-    };
-    const syncPendingSeek = () => {
-      if (!restorePending) return;
-      if (suppressNextHlsSeekSync) {
-        suppressNextHlsSeekSync = false;
-        return;
-      }
-      pendingResumeAt = readCurrentTime();
-      playbackStateRef.current = { currentTime: pendingResumeAt, shouldResume };
-
-      const hls = hlsRef.current;
-      if (hls && hlsManifestParsed) {
-        hls.startLoad(pendingResumeAt > 0 ? pendingResumeAt : 0);
-      }
-    };
-    const finishRestore = () => {
-      restorePending = false;
-      video.removeEventListener("canplay", finishRestore);
-      video.removeEventListener("playing", finishRestore);
-    };
-    const resumePlayback = () => {
-      if (shouldResume && !resumedAfterRestore) {
-        resumedAfterRestore = true;
-        requestPlayback();
-      }
-    };
-    const removeNativeRestoreListeners = () => {
-      video.removeEventListener("canplay", restoreNativePlayback);
-      video.removeEventListener("durationchange", restoreNativePlayback);
-      video.removeEventListener("loadeddata", restoreNativePlayback);
-      video.removeEventListener("loadedmetadata", restoreNativePlayback);
-      video.removeEventListener("seeking", syncPendingSeek);
-    };
-    const restoreNativePlayback = () => {
-      if (pendingResumeAt > 0) {
-        const duration = video.duration;
-        if (
-          Number.isFinite(duration) &&
-          duration <= pendingResumeAt + RESUME_DURATION_TOLERANCE_SECONDS
-        ) {
-          return;
-        }
-
-        try {
-          video.currentTime = pendingResumeAt;
-        } catch {
-          return;
-        }
-      }
-
-      finishRestore();
-      resumePlayback();
-      removeNativeRestoreListeners();
-    };
-
-    const attachNativePlayback = () => {
-      const onNativePlaybackError = () => {
-        setPlaybackError("Playback failed because the video segments could not be loaded.");
-      };
-      const rememberNativeSeekIntent = () => {
-        nativeSeekResumeAt = readCurrentTime();
-        nativeSeekShouldResume = restorePending ? wantsPlayback() || shouldResume : wantsPlayback();
-        if (nativeSeekShouldResume) scheduleNativeSeekRecovery();
-      };
-      const resumeAfterNativeSeek = () => {
-        nativeSeekResumeAt = readCurrentTime();
-        if (!nativeSeekShouldResume) return;
-        requestPlayback();
-        scheduleNativeSeekRecovery();
-      };
-      const finishNativeSeekRecovery = () => {
-        nativeSeekShouldResume = false;
-        clearNativeSeekRecoveryTimer();
-      };
-      const recoverNativeSeekStall = () => {
-        if (!nativeSeekShouldResume && !wantsPlayback()) return;
-        nativeSeekResumeAt = readCurrentTime();
-        nativeSeekShouldResume = true;
-        scheduleNativeSeekRecovery();
-      };
-      const cancelNativeSeekRecovery = () => {
-        if (video.seeking) return;
-        nativeSeekShouldResume = false;
-        clearNativeSeekRecoveryTimer();
-      };
-      video.addEventListener("canplay", restoreNativePlayback);
-      video.addEventListener("durationchange", restoreNativePlayback);
-      video.addEventListener("loadeddata", restoreNativePlayback);
-      video.addEventListener("loadedmetadata", restoreNativePlayback);
-      video.addEventListener("seeking", syncPendingSeek);
-      video.addEventListener("seeking", rememberNativeSeekIntent);
-      video.addEventListener("seeked", resumeAfterNativeSeek);
-      video.addEventListener("canplay", resumeAfterNativeSeek);
-      video.addEventListener("playing", finishNativeSeekRecovery);
-      video.addEventListener("pause", cancelNativeSeekRecovery);
-      video.addEventListener("stalled", recoverNativeSeekStall);
-      video.addEventListener("waiting", recoverNativeSeekStall);
-      video.addEventListener("error", onNativePlaybackError, { once: true });
-      video.src = src;
-      video.load();
-      cleanupPlayback = () => {
-        clearNativeSeekRecoveryTimer();
-        removeNativeRestoreListeners();
-        video.removeEventListener("seeking", rememberNativeSeekIntent);
-        video.removeEventListener("seeked", resumeAfterNativeSeek);
-        video.removeEventListener("canplay", resumeAfterNativeSeek);
-        video.removeEventListener("playing", finishNativeSeekRecovery);
-        video.removeEventListener("pause", cancelNativeSeekRecovery);
-        video.removeEventListener("stalled", recoverNativeSeekStall);
-        video.removeEventListener("waiting", recoverNativeSeekStall);
-        video.removeEventListener("error", onNativePlaybackError);
-        video.removeAttribute("src");
-        video.load();
-      };
-    };
-
-    import("hls.js")
-      .then(({ default: Hls }) => {
-        if (!active) return;
-        if (Hls.isSupported()) {
-          let mediaRecoveryAttempts = 0;
-          let networkRecoveryAttempts = 0;
-          const hls = new Hls({
-            enableWorker: true,
-            ...HLS_RETRY_CONFIG,
-            autoStartLoad: resumeAt > 0 ? false : true,
-            lowLatencyMode: false,
-            startPosition: resumeAt > 0 ? resumeAt : -1,
-          });
-          hlsRef.current = hls;
-          hls.loadSource(src);
-          hls.attachMedia(video);
-          video.addEventListener("canplay", finishRestore);
-          video.addEventListener("playing", finishRestore);
-          video.addEventListener("seeking", syncPendingSeek);
-          const hlsLoadPosition = () => {
-            const currentTime = readCurrentTime();
-            if (
-              restorePending &&
-              pendingResumeAt > RESUME_DURATION_TOLERANCE_SECONDS &&
-              currentTime <= RESUME_DURATION_TOLERANCE_SECONDS
-            ) {
-              return pendingResumeAt;
-            }
-            return currentTime > 0 ? currentTime : 0;
-          };
-          const recoverHlsPlayback = () => {
-            if (!active || video.ended || video.paused || !wantsPlayback()) return;
-            const loadPosition = hlsLoadPosition();
-            hls.startLoad(loadPosition);
-            seekVideoTo(loadPosition);
-          };
-          video.addEventListener("stalled", recoverHlsPlayback);
-          video.addEventListener("waiting", recoverHlsPlayback);
-          hls.on(Hls.Events.MANIFEST_PARSED, () => {
-            hlsManifestParsed = true;
-            if (restorePending) {
-              const loadPosition = hlsLoadPosition();
-              hls.startLoad(loadPosition);
-              seekVideoTo(loadPosition);
-            }
-            resumePlayback();
-          });
-          hls.on(Hls.Events.ERROR, (_event, data) => {
-            if (data?.fatal) {
-              if (
-                data.type === Hls.ErrorTypes.NETWORK_ERROR &&
-                networkRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
-              ) {
-                networkRecoveryAttempts += 1;
-                const loadPosition = hlsLoadPosition();
-                hls.startLoad(loadPosition);
-                seekVideoTo(loadPosition);
-                return;
-              }
-
-              if (
-                data.type === Hls.ErrorTypes.MEDIA_ERROR &&
-                mediaRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
-              ) {
-                mediaRecoveryAttempts += 1;
-                seekVideoTo(hlsLoadPosition());
-                hls.recoverMediaError();
-                return;
-              }
-
-              setPlaybackError("Playback failed because the video segments could not be loaded.");
-            }
-          });
-          cleanupPlayback = () => {
-            video.removeEventListener("canplay", finishRestore);
-            video.removeEventListener("playing", finishRestore);
-            video.removeEventListener("seeking", syncPendingSeek);
-            video.removeEventListener("stalled", recoverHlsPlayback);
-            video.removeEventListener("waiting", recoverHlsPlayback);
-            hls.destroy();
-            hlsRef.current = null;
-          };
-          return;
-        }
-
-        if (video.canPlayType("application/vnd.apple.mpegurl")) {
-          attachNativePlayback();
-        }
-      })
-      .catch(() => {
-        if (active && video.canPlayType("application/vnd.apple.mpegurl")) {
-          attachNativePlayback();
-        }
-      });
-
-    return () => {
-      active = false;
-      capturePlaybackStateFromVideo(video);
-      cleanupPlayback();
-      hlsRef.current = null;
-    };
-  }, [capturePlaybackStateFromVideo, src]);
 
   useEffect(() => {
     const video = videoRef.current;
@@ -421,9 +75,7 @@ export default function VideoPlayer({
       video.removeEventListener("pause", handlePause);
       video.removeEventListener("ended", handleEnded);
     };
-  }, [clearControlsIdleTimer, scheduleControlsIdleHide]);
-
-  useEffect(() => clearControlsIdleTimer, [clearControlsIdleTimer]);
+  }, [clearControlsIdleTimer, playbackIntentRef, scheduleControlsIdleHide, setControlsActive]);
 
   useEffect(() => {
     setQualityOpen(false);
@@ -441,48 +93,17 @@ export default function VideoPlayer({
       <video ref={videoRef} className="player" controls playsInline />
       {playbackError && <div className="player-error">{playbackError}</div>}
       {variants.length > 0 && (
-        <div
-          className={`player-quality${qualityOpen ? " open" : ""}`}
-          onMouseLeave={() => setQualityOpen(false)}
-          onBlur={(event: FocusEvent<HTMLDivElement>) => {
-            const nextTarget = event.relatedTarget instanceof Node ? event.relatedTarget : null;
-            if (!event.currentTarget.contains(nextTarget)) setQualityOpen(false);
+        <QualityMenu
+          variants={variants}
+          resolution={resolution}
+          open={qualityOpen}
+          onOpenChange={setQualityOpen}
+          onToggle={() => {
+            setQualityOpen((open) => !open);
+            showControls();
           }}
-        >
-          <button
-            type="button"
-            className={`quality-toggle${qualityOpen ? " active" : ""}`}
-            aria-label="Quality"
-            aria-expanded={qualityOpen}
-            aria-haspopup="menu"
-            onClick={() => {
-              setQualityOpen((open) => !open);
-              showControls();
-            }}
-          >
-            <span className="gear-icon" aria-hidden="true" />
-            <span>{selectedLabel}</span>
-          </button>
-          {qualityOpen && (
-            <div className="quality-menu" role="menu" aria-label="Video quality">
-              {variants.map((variant) => {
-                const label = variantDisplayLabel(variant.resolution);
-                return (
-                  <button
-                    key={variant.id}
-                    type="button"
-                    role="menuitemradio"
-                    aria-checked={variant.resolution === resolution}
-                    className={variant.resolution === resolution ? "active" : ""}
-                    onClick={() => handleResolutionChange(variant.resolution)}
-                  >
-                    {label}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-        </div>
+          onSelect={handleResolutionChange}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/library/CatalogPanel.tsx
+++ b/apps/web/src/components/library/CatalogPanel.tsx
@@ -1,0 +1,75 @@
+import type { AdminCatalogs } from "../../types";
+
+interface CatalogPanelProps {
+  catalogCopied: string;
+  catalogPublishing: boolean;
+  catalogs: AdminCatalogs | null;
+  onCopy: (label: string, address?: string | null) => void;
+  onRepublish: () => void;
+}
+
+export default function CatalogPanel({
+  catalogs,
+  catalogPublishing,
+  catalogCopied,
+  onCopy,
+  onRepublish,
+}: CatalogPanelProps) {
+  return (
+    <div className="catalog-address-panel">
+      <div className="catalog-address-head">
+        <div>
+          <strong>Portable catalogs</strong>
+          <span>
+            Published {catalogs?.published_catalog?.videos.length ?? 0} / all{" "}
+            {catalogs?.all_catalog?.videos.length ?? 0}
+          </span>
+        </div>
+        <button
+          type="button"
+          className="secondary-action"
+          disabled={catalogPublishing}
+          onClick={onRepublish}
+        >
+          {catalogPublishing ? "Publishing..." : "Republish"}
+        </button>
+      </div>
+      <div className="catalog-address-grid">
+        <CatalogAddress
+          label="Published"
+          address={catalogs?.published_catalog_address}
+          copied={catalogCopied === "published"}
+          onCopy={() => onCopy("published", catalogs?.published_catalog_address)}
+        />
+        <CatalogAddress
+          label="All"
+          address={catalogs?.all_catalog_address}
+          copied={catalogCopied === "all"}
+          onCopy={() => onCopy("all", catalogs?.all_catalog_address)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CatalogAddress({
+  address,
+  copied,
+  label,
+  onCopy,
+}: {
+  address?: string | null;
+  copied: boolean;
+  label: string;
+  onCopy: () => void;
+}) {
+  return (
+    <div className="catalog-address-row">
+      <span>{label}</span>
+      <code>{address || "Not published yet"}</code>
+      <button type="button" className="secondary-action" disabled={!address} onClick={onCopy}>
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/library/VideoDetailPane.tsx
+++ b/apps/web/src/components/library/VideoDetailPane.tsx
@@ -1,0 +1,113 @@
+import type { MouseEvent } from "react";
+
+import type { VideoDetail, VisibilityUpdate } from "../../types";
+import FinalQuotePanel from "../FinalQuotePanel";
+import VideoPlayer from "../VideoPlayer";
+
+interface VideoDetailPaneProps {
+  admin: boolean;
+  approving: boolean;
+  detail: VideoDetail;
+  onApprove: () => void;
+  onDelete: (event: MouseEvent<HTMLButtonElement>) => void;
+  onResolutionChange: (resolution: string) => void;
+  onUpdatePublication: (isPublic: boolean) => void;
+  onUpdateVisibility: (next: VisibilityUpdate) => void;
+  publishing: boolean;
+  selectedResolution: string | null;
+}
+
+export default function VideoDetailPane({
+  admin,
+  detail,
+  approving,
+  publishing,
+  selectedResolution,
+  onApprove,
+  onDelete,
+  onResolutionChange,
+  onUpdatePublication,
+  onUpdateVisibility,
+}: VideoDetailPaneProps) {
+  const selectedVariant =
+    detail.variants.find((variant) => variant.resolution === selectedResolution) ||
+    detail.variants[0];
+
+  return (
+    <div className="video-detail">
+      {admin && detail.status === "awaiting_approval" ? (
+        <FinalQuotePanel
+          quote={detail.final_quote}
+          expiresAt={detail.approval_expires_at}
+          approving={approving}
+          onApprove={onApprove}
+        />
+      ) : admin && detail.status === "uploading" ? (
+        <p className="muted">Uploading approved segments and publishing the network manifest...</p>
+      ) : admin && (detail.status === "processing" || detail.status === "pending") ? (
+        <p className="muted">Processing renditions and preparing the final quote...</p>
+      ) : admin && (detail.status === "error" || detail.status === "expired") ? (
+        <p className="muted">{detail.error_message || "This video could not be completed."}</p>
+      ) : detail.variants.length === 0 ? (
+        <p className="muted">No variants available.</p>
+      ) : (
+        <VideoPlayer
+          videoId={detail.id}
+          manifestAddress={admin ? detail.manifest_address : null}
+          variants={detail.variants}
+          resolution={selectedVariant.resolution}
+          onResolutionChange={onResolutionChange}
+        />
+      )}
+      {admin && (
+        <>
+          {detail.status === "ready" && (
+            <div className="publication-panel">
+              <button
+                type="button"
+                className={detail.is_public ? "secondary-action" : "primary-action compact-action"}
+                disabled={publishing}
+                onClick={() => onUpdatePublication(!detail.is_public)}
+              >
+                {publishing ? "Updating..." : detail.is_public ? "Unpublish" : "Publish"}
+              </button>
+              <span className={`status ${detail.is_public ? "public" : "private"}`}>
+                {detail.is_public ? "public" : "hidden"}
+              </span>
+            </div>
+          )}
+          <div className="visibility-panel">
+            <label>
+              <input
+                type="checkbox"
+                checked={!!detail.show_manifest_address}
+                onChange={(event) =>
+                  onUpdateVisibility({
+                    show_original_filename: false,
+                    show_manifest_address: event.target.checked,
+                  })
+                }
+              />
+              <span>Publish manifest address</span>
+            </label>
+          </div>
+        </>
+      )}
+      {(admin || detail.manifest_address) && (
+        <div className="detail-footer">
+          <div className="detail-addresses">
+            <code>{detail.manifest_address || "Manifest hidden or pending"}</code>
+            {admin && detail.original_file_address && (
+              <code>Original source: {detail.original_file_address}</code>
+            )}
+          </div>
+          {admin && (
+            <button type="button" className="danger-action" onClick={onDelete}>
+              Delete
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/player/QualityMenu.tsx
+++ b/apps/web/src/components/player/QualityMenu.tsx
@@ -1,0 +1,66 @@
+import type { FocusEvent } from "react";
+
+import type { VideoVariant } from "../../types";
+import { variantDisplayLabel } from "../../utils/resolutions";
+
+interface QualityMenuProps {
+  onOpenChange: (open: boolean) => void;
+  onSelect: (resolution: string) => void;
+  onToggle: () => void;
+  open: boolean;
+  resolution: string;
+  variants: VideoVariant[];
+}
+
+export default function QualityMenu({
+  variants,
+  resolution,
+  open,
+  onOpenChange,
+  onToggle,
+  onSelect,
+}: QualityMenuProps) {
+  const selectedLabel = variantDisplayLabel(resolution);
+
+  return (
+    <div
+      className={`player-quality${open ? " open" : ""}`}
+      onMouseLeave={() => onOpenChange(false)}
+      onBlur={(event: FocusEvent<HTMLDivElement>) => {
+        const nextTarget = event.relatedTarget instanceof Node ? event.relatedTarget : null;
+        if (!event.currentTarget.contains(nextTarget)) onOpenChange(false);
+      }}
+    >
+      <button
+        type="button"
+        className={`quality-toggle${open ? " active" : ""}`}
+        aria-label="Quality"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        onClick={onToggle}
+      >
+        <span className="gear-icon" aria-hidden="true" />
+        <span>{selectedLabel}</span>
+      </button>
+      {open && (
+        <div className="quality-menu" role="menu" aria-label="Video quality">
+          {variants.map((variant) => {
+            const label = variantDisplayLabel(variant.resolution);
+            return (
+              <button
+                key={variant.id}
+                type="button"
+                role="menuitemradio"
+                aria-checked={variant.resolution === resolution}
+                className={variant.resolution === resolution ? "active" : ""}
+                onClick={() => onSelect(variant.resolution)}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/upload/EncodeSettingsFields.tsx
+++ b/apps/web/src/components/upload/EncodeSettingsFields.tsx
@@ -1,0 +1,144 @@
+import type { SourceVideoMeta } from "../../types";
+import type { VideoCodec } from "../../hooks/useUploadWorkflow";
+import { RESOLUTION_OPTIONS } from "../../constants";
+import {
+  optionFitsSource,
+  orderedSelection,
+  resolutionByValue,
+  targetDimensionsForMeta,
+} from "../../utils/resolutions";
+
+interface CurrentProfile {
+  label: string;
+  value: string;
+}
+
+interface EncodeSettingsFieldsProps {
+  audioBitrateKbps: number;
+  currentProfile: CurrentProfile | null | undefined;
+  file: File | null;
+  meta: SourceVideoMeta | null;
+  onAudioBitrateChange: (kbps: number) => void;
+  onCodecChange: (codec: VideoCodec) => void;
+  onSelectAdaptive: () => void;
+  onSelectCurrentOnly: () => void;
+  onToggleRes: (resolution: string) => void;
+  onVideoBitrateChange: (resolution: string, kbps: number) => void;
+  selected: string[];
+  uploading: boolean;
+  videoBitrates: Record<string, number>;
+  videoCodec: VideoCodec;
+}
+
+export default function EncodeSettingsFields({
+  file,
+  meta,
+  currentProfile,
+  selected,
+  videoCodec,
+  audioBitrateKbps,
+  videoBitrates,
+  uploading,
+  onCodecChange,
+  onAudioBitrateChange,
+  onVideoBitrateChange,
+  onToggleRes,
+  onSelectCurrentOnly,
+  onSelectAdaptive,
+}: EncodeSettingsFieldsProps) {
+  return (
+    <>
+      <div className="encoding-panel">
+        <div className="encoding-row">
+          <label>
+            <span>Video codec</span>
+            <select
+              value={videoCodec}
+              onChange={(event) => onCodecChange(event.target.value as VideoCodec)}
+              disabled={uploading}
+            >
+              <option value="h264">H.264</option>
+              <option value="hevc">HEVC / H.265</option>
+            </select>
+          </label>
+          <label>
+            <span>Audio bitrate</span>
+            <input
+              type="number"
+              min={32}
+              max={1024}
+              step={32}
+              value={audioBitrateKbps}
+              onChange={(event) => onAudioBitrateChange(Number(event.target.value))}
+              disabled={uploading}
+            />
+          </label>
+        </div>
+        <div className="bitrate-grid">
+          {orderedSelection(selected).map((resolution) => {
+            const option = resolutionByValue(resolution);
+            return (
+              <label key={resolution}>
+                <span>{option?.label || resolution}</span>
+                <input
+                  type="number"
+                  min={64}
+                  max={200000}
+                  step={1}
+                  value={videoBitrates[resolution] || 0}
+                  onChange={(event) => onVideoBitrateChange(resolution, Number(event.target.value))}
+                  disabled={uploading}
+                />
+              </label>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="resolution-toolbar">
+        <div>
+          <span className="meta-label">Renditions to create</span>
+          <p>Higher-than-source options are dimmed to avoid accidental upscales.</p>
+        </div>
+        <div className="quick-actions">
+          <button
+            type="button"
+            onClick={onSelectCurrentOnly}
+            disabled={!currentProfile || uploading}
+          >
+            Current only
+          </button>
+          <button type="button" onClick={onSelectAdaptive} disabled={!file || uploading}>
+            Current + lower
+          </button>
+        </div>
+      </div>
+
+      <div className="resolution-grid">
+        {RESOLUTION_OPTIONS.map((option) => {
+          const isCurrent = currentProfile?.value === option.value;
+          const disabledBySource = !!file && !optionFitsSource(option, meta);
+          const targetDimensions = targetDimensionsForMeta(option, meta);
+          return (
+            <button
+              key={option.value}
+              type="button"
+              className={`resolution-card ${selected.includes(option.value) ? "selected" : ""}`}
+              onClick={() => !disabledBySource && onToggleRes(option.value)}
+              disabled={uploading || disabledBySource}
+            >
+              <span className="resolution-label">{option.label}</span>
+              <span>
+                {targetDimensions.width} x {targetDimensions.height}
+              </span>
+              <span>
+                {option.bitrate} · {option.note}
+              </span>
+              {isCurrent && <strong>Current source profile</strong>}
+            </button>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/upload/FileDropZone.tsx
+++ b/apps/web/src/components/upload/FileDropZone.tsx
@@ -1,0 +1,50 @@
+import { useState, type DragEvent, type RefObject } from "react";
+
+import { formatBytes } from "../../utils/format";
+
+interface FileDropZoneProps {
+  file: File | null;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  onFile: (file?: File) => void;
+  uploading: boolean;
+}
+
+export default function FileDropZone({ file, fileInputRef, onFile, uploading }: FileDropZoneProps) {
+  const [dragging, setDragging] = useState(false);
+
+  const onDrop = (event: DragEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    setDragging(false);
+    onFile(event.dataTransfer.files?.[0]);
+  };
+
+  return (
+    <button
+      type="button"
+      className={`dropzone ${dragging ? "is-dragging" : ""}`}
+      onClick={() => fileInputRef.current?.click()}
+      onDragEnter={(event) => {
+        event.preventDefault();
+        setDragging(true);
+      }}
+      onDragOver={(event) => event.preventDefault()}
+      onDragLeave={() => setDragging(false)}
+      onDrop={onDrop}
+      disabled={uploading}
+    >
+      <input
+        ref={fileInputRef}
+        className="hidden-input"
+        type="file"
+        accept="video/*"
+        onChange={(event) => onFile(event.target.files?.[0])}
+        disabled={uploading}
+      />
+      <span className="drop-icon">+</span>
+      <span className="drop-title">{file ? file.name : "Drag and drop a video file"}</span>
+      <span className="drop-subtitle">
+        {file ? `${formatBytes(file.size)} selected` : "or click to browse from your machine"}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/upload/FileDropZone.tsx
+++ b/apps/web/src/components/upload/FileDropZone.tsx
@@ -1,10 +1,10 @@
-import { useState, type DragEvent, type RefObject } from "react";
+import { useState, type DragEvent, type MutableRefObject } from "react";
 
 import { formatBytes } from "../../utils/format";
 
 interface FileDropZoneProps {
   file: File | null;
-  fileInputRef: RefObject<HTMLInputElement | null>;
+  fileInputRef: MutableRefObject<HTMLInputElement | null>;
   onFile: (file?: File) => void;
   uploading: boolean;
 }

--- a/apps/web/src/components/upload/UploadQuoteSummary.tsx
+++ b/apps/web/src/components/upload/UploadQuoteSummary.tsx
@@ -1,0 +1,34 @@
+import type { QuoteState } from "../../hooks/useUploadWorkflow";
+import { formatAttoTokens, formatBytes, formatWei } from "../../utils/format";
+
+export default function UploadQuoteSummary({ quote }: { quote: QuoteState }) {
+  return (
+    <div className="quote-panel">
+      <div className="quote-main">
+        <span className="meta-label">Upload price quote</span>
+        {quote.loading && <strong>Quoting Autonomi storage...</strong>}
+        {!quote.loading && quote.data && (
+          <strong>{formatAttoTokens(quote.data.storage_cost_atto)}</strong>
+        )}
+        {!quote.loading && !quote.data && (
+          <strong>{quote.error ? "Quote unavailable" : "Waiting for video duration"}</strong>
+        )}
+        <p>
+          {quote.data
+            ? `${formatBytes(quote.data.estimated_bytes)} across ${quote.data.segment_count} HLS segments${quote.data.original_file ? ", original file," : ""} and metadata`
+            : quote.error || "The estimate refreshes when renditions change."}
+        </p>
+      </div>
+      {quote.data && (
+        <div className="quote-breakdown">
+          <span>{formatWei(quote.data.estimated_gas_cost_wei)}</span>
+          <span>{quote.data.payment_mode} payment mode</span>
+          {quote.data.original_file && (
+            <span>{formatBytes(quote.data.original_file.estimated_bytes)} original source</span>
+          )}
+          {quote.data.sampled && <span>large segment estimate sampled</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useControlsVisibility.ts
+++ b/apps/web/src/hooks/useControlsVisibility.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+
+import { PLAYER_CONTROLS_IDLE_MS } from "../constants";
+
+/**
+ * Show/hide state for the player overlay controls with an idle-hide timer.
+ * `onHide` fires whenever the controls hide (pointer leave or idle timeout)
+ * so callers can close popovers such as the quality menu.
+ */
+export function useControlsVisibility(
+  videoRef: RefObject<HTMLVideoElement | null>,
+  onHide: () => void,
+) {
+  const controlsIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [controlsActive, setControlsActive] = useState(true);
+
+  const clearControlsIdleTimer = useCallback(() => {
+    if (controlsIdleTimerRef.current) {
+      clearTimeout(controlsIdleTimerRef.current);
+      controlsIdleTimerRef.current = null;
+    }
+  }, []);
+
+  const hideControls = useCallback(() => {
+    clearControlsIdleTimer();
+    onHide();
+    setControlsActive(false);
+  }, [clearControlsIdleTimer, onHide]);
+
+  const scheduleControlsIdleHide = useCallback(() => {
+    clearControlsIdleTimer();
+    const video = videoRef.current;
+    if (!video || video.paused || video.ended) return;
+
+    controlsIdleTimerRef.current = setTimeout(() => {
+      onHide();
+      setControlsActive(false);
+      controlsIdleTimerRef.current = null;
+    }, PLAYER_CONTROLS_IDLE_MS);
+  }, [clearControlsIdleTimer, onHide, videoRef]);
+
+  const showControls = useCallback(() => {
+    setControlsActive(true);
+    scheduleControlsIdleHide();
+  }, [scheduleControlsIdleHide]);
+
+  useEffect(() => clearControlsIdleTimer, [clearControlsIdleTimer]);
+
+  return {
+    controlsActive,
+    setControlsActive,
+    showControls,
+    hideControls,
+    scheduleControlsIdleHide,
+    clearControlsIdleTimer,
+  };
+}

--- a/apps/web/src/hooks/useHlsPlayer.ts
+++ b/apps/web/src/hooks/useHlsPlayer.ts
@@ -1,0 +1,340 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import type Hls from "hls.js";
+
+import { RESUME_DURATION_TOLERANCE_SECONDS } from "../constants";
+
+const HLS_RETRY_CONFIG = {
+  fragLoadingMaxRetry: 4,
+  fragLoadingMaxRetryTimeout: 8_000,
+  fragLoadingRetryDelay: 500,
+  levelLoadingMaxRetry: 4,
+  levelLoadingMaxRetryTimeout: 8_000,
+  levelLoadingRetryDelay: 500,
+  manifestLoadingMaxRetry: 4,
+  manifestLoadingMaxRetryTimeout: 8_000,
+  manifestLoadingRetryDelay: 500,
+};
+const HLS_FATAL_RECOVERY_ATTEMPTS = 1;
+const MEDIA_HAVE_FUTURE_DATA = 3;
+
+interface PlaybackState {
+  currentTime: number;
+  shouldResume: boolean;
+}
+
+/**
+ * Owns the hls.js / native-HLS playback lifecycle for a <video> element:
+ * source attachment, resume-position restoration across quality switches,
+ * seek/stall recovery, and fatal error handling. The seek-sync suppression
+ * logic is timing-sensitive; treat it as behavior, not style.
+ */
+export function useHlsPlayer(videoRef: RefObject<HTMLVideoElement | null>, src: string) {
+  const hlsRef = useRef<Hls | null>(null);
+  const playbackStateRef = useRef<PlaybackState>({ currentTime: 0, shouldResume: false });
+  const playbackIntentRef = useRef(false);
+  const [playbackError, setPlaybackError] = useState("");
+
+  const capturePlaybackStateFromVideo = useCallback((video: HTMLVideoElement) => {
+    playbackStateRef.current = {
+      currentTime: Number.isFinite(video.currentTime) ? video.currentTime : 0,
+      shouldResume: playbackIntentRef.current || (!video.paused && !video.ended),
+    };
+  }, []);
+
+  const capturePlaybackState = useCallback(() => {
+    const video = videoRef.current;
+    if (!video) return;
+    capturePlaybackStateFromVideo(video);
+  }, [capturePlaybackStateFromVideo, videoRef]);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return undefined;
+
+    setPlaybackError("");
+    let active = true;
+    let cleanupPlayback = () => {};
+    const { currentTime: resumeAt, shouldResume } = playbackStateRef.current;
+    let pendingResumeAt = resumeAt;
+    let restorePending = resumeAt > 0;
+    let hlsManifestParsed = false;
+    let resumedAfterRestore = false;
+    let suppressNextHlsSeekSync = false;
+    let nativeSeekRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+    let nativeSeekResumeAt = 0;
+    let nativeSeekShouldResume = false;
+    const readCurrentTime = () => (Number.isFinite(video.currentTime) ? video.currentTime : 0);
+    const seekVideoTo = (targetTime: number) => {
+      if (targetTime <= 0) return;
+
+      const duration = video.duration;
+      if (Number.isFinite(duration) && duration <= targetTime + RESUME_DURATION_TOLERANCE_SECONDS) {
+        return;
+      }
+
+      if (Math.abs(readCurrentTime() - targetTime) <= RESUME_DURATION_TOLERANCE_SECONDS) {
+        return;
+      }
+
+      try {
+        suppressNextHlsSeekSync = true;
+        video.currentTime = targetTime;
+      } catch {
+        suppressNextHlsSeekSync = false;
+        // MediaSource can briefly reject seeks while hls.js is rebuilding buffers.
+      }
+    };
+    const clearNativeSeekRecoveryTimer = () => {
+      if (nativeSeekRecoveryTimer) {
+        clearTimeout(nativeSeekRecoveryTimer);
+        nativeSeekRecoveryTimer = null;
+      }
+    };
+    const wantsPlayback = () => playbackIntentRef.current || (!video.paused && !video.ended);
+    const requestPlayback = () => {
+      playbackIntentRef.current = true;
+      video.play().catch(() => {});
+    };
+    const scheduleNativeSeekRecovery = () => {
+      clearNativeSeekRecoveryTimer();
+      if (!nativeSeekShouldResume) return;
+
+      nativeSeekRecoveryTimer = setTimeout(() => {
+        nativeSeekRecoveryTimer = null;
+        if (!active || !nativeSeekShouldResume || video.ended) return;
+
+        if (video.paused || video.readyState < MEDIA_HAVE_FUTURE_DATA) {
+          try {
+            if (
+              Math.abs(readCurrentTime() - nativeSeekResumeAt) > RESUME_DURATION_TOLERANCE_SECONDS
+            ) {
+              video.currentTime = nativeSeekResumeAt;
+            }
+          } catch {
+            // Safari can reject seeks while native HLS is swapping internal buffers.
+          }
+          requestPlayback();
+          scheduleNativeSeekRecovery();
+        }
+      }, 750);
+    };
+    const syncPendingSeek = () => {
+      if (!restorePending) return;
+      if (suppressNextHlsSeekSync) {
+        suppressNextHlsSeekSync = false;
+        return;
+      }
+      pendingResumeAt = readCurrentTime();
+      playbackStateRef.current = { currentTime: pendingResumeAt, shouldResume };
+
+      const hls = hlsRef.current;
+      if (hls && hlsManifestParsed) {
+        hls.startLoad(pendingResumeAt > 0 ? pendingResumeAt : 0);
+      }
+    };
+    const finishRestore = () => {
+      restorePending = false;
+      video.removeEventListener("canplay", finishRestore);
+      video.removeEventListener("playing", finishRestore);
+    };
+    const resumePlayback = () => {
+      if (shouldResume && !resumedAfterRestore) {
+        resumedAfterRestore = true;
+        requestPlayback();
+      }
+    };
+    const removeNativeRestoreListeners = () => {
+      video.removeEventListener("canplay", restoreNativePlayback);
+      video.removeEventListener("durationchange", restoreNativePlayback);
+      video.removeEventListener("loadeddata", restoreNativePlayback);
+      video.removeEventListener("loadedmetadata", restoreNativePlayback);
+      video.removeEventListener("seeking", syncPendingSeek);
+    };
+    const restoreNativePlayback = () => {
+      if (pendingResumeAt > 0) {
+        const duration = video.duration;
+        if (
+          Number.isFinite(duration) &&
+          duration <= pendingResumeAt + RESUME_DURATION_TOLERANCE_SECONDS
+        ) {
+          return;
+        }
+
+        try {
+          video.currentTime = pendingResumeAt;
+        } catch {
+          return;
+        }
+      }
+
+      finishRestore();
+      resumePlayback();
+      removeNativeRestoreListeners();
+    };
+
+    const attachNativePlayback = () => {
+      const onNativePlaybackError = () => {
+        setPlaybackError("Playback failed because the video segments could not be loaded.");
+      };
+      const rememberNativeSeekIntent = () => {
+        nativeSeekResumeAt = readCurrentTime();
+        nativeSeekShouldResume = restorePending ? wantsPlayback() || shouldResume : wantsPlayback();
+        if (nativeSeekShouldResume) scheduleNativeSeekRecovery();
+      };
+      const resumeAfterNativeSeek = () => {
+        nativeSeekResumeAt = readCurrentTime();
+        if (!nativeSeekShouldResume) return;
+        requestPlayback();
+        scheduleNativeSeekRecovery();
+      };
+      const finishNativeSeekRecovery = () => {
+        nativeSeekShouldResume = false;
+        clearNativeSeekRecoveryTimer();
+      };
+      const recoverNativeSeekStall = () => {
+        if (!nativeSeekShouldResume && !wantsPlayback()) return;
+        nativeSeekResumeAt = readCurrentTime();
+        nativeSeekShouldResume = true;
+        scheduleNativeSeekRecovery();
+      };
+      const cancelNativeSeekRecovery = () => {
+        if (video.seeking) return;
+        nativeSeekShouldResume = false;
+        clearNativeSeekRecoveryTimer();
+      };
+      video.addEventListener("canplay", restoreNativePlayback);
+      video.addEventListener("durationchange", restoreNativePlayback);
+      video.addEventListener("loadeddata", restoreNativePlayback);
+      video.addEventListener("loadedmetadata", restoreNativePlayback);
+      video.addEventListener("seeking", syncPendingSeek);
+      video.addEventListener("seeking", rememberNativeSeekIntent);
+      video.addEventListener("seeked", resumeAfterNativeSeek);
+      video.addEventListener("canplay", resumeAfterNativeSeek);
+      video.addEventListener("playing", finishNativeSeekRecovery);
+      video.addEventListener("pause", cancelNativeSeekRecovery);
+      video.addEventListener("stalled", recoverNativeSeekStall);
+      video.addEventListener("waiting", recoverNativeSeekStall);
+      video.addEventListener("error", onNativePlaybackError, { once: true });
+      video.src = src;
+      video.load();
+      cleanupPlayback = () => {
+        clearNativeSeekRecoveryTimer();
+        removeNativeRestoreListeners();
+        video.removeEventListener("seeking", rememberNativeSeekIntent);
+        video.removeEventListener("seeked", resumeAfterNativeSeek);
+        video.removeEventListener("canplay", resumeAfterNativeSeek);
+        video.removeEventListener("playing", finishNativeSeekRecovery);
+        video.removeEventListener("pause", cancelNativeSeekRecovery);
+        video.removeEventListener("stalled", recoverNativeSeekStall);
+        video.removeEventListener("waiting", recoverNativeSeekStall);
+        video.removeEventListener("error", onNativePlaybackError);
+        video.removeAttribute("src");
+        video.load();
+      };
+    };
+
+    import("hls.js")
+      .then(({ default: Hls }) => {
+        if (!active) return;
+        if (Hls.isSupported()) {
+          let mediaRecoveryAttempts = 0;
+          let networkRecoveryAttempts = 0;
+          const hls = new Hls({
+            enableWorker: true,
+            ...HLS_RETRY_CONFIG,
+            autoStartLoad: resumeAt > 0 ? false : true,
+            lowLatencyMode: false,
+            startPosition: resumeAt > 0 ? resumeAt : -1,
+          });
+          hlsRef.current = hls;
+          hls.loadSource(src);
+          hls.attachMedia(video);
+          video.addEventListener("canplay", finishRestore);
+          video.addEventListener("playing", finishRestore);
+          video.addEventListener("seeking", syncPendingSeek);
+          const hlsLoadPosition = () => {
+            const currentTime = readCurrentTime();
+            if (
+              restorePending &&
+              pendingResumeAt > RESUME_DURATION_TOLERANCE_SECONDS &&
+              currentTime <= RESUME_DURATION_TOLERANCE_SECONDS
+            ) {
+              return pendingResumeAt;
+            }
+            return currentTime > 0 ? currentTime : 0;
+          };
+          const recoverHlsPlayback = () => {
+            if (!active || video.ended || video.paused || !wantsPlayback()) return;
+            const loadPosition = hlsLoadPosition();
+            hls.startLoad(loadPosition);
+            seekVideoTo(loadPosition);
+          };
+          video.addEventListener("stalled", recoverHlsPlayback);
+          video.addEventListener("waiting", recoverHlsPlayback);
+          hls.on(Hls.Events.MANIFEST_PARSED, () => {
+            hlsManifestParsed = true;
+            if (restorePending) {
+              const loadPosition = hlsLoadPosition();
+              hls.startLoad(loadPosition);
+              seekVideoTo(loadPosition);
+            }
+            resumePlayback();
+          });
+          hls.on(Hls.Events.ERROR, (_event, data) => {
+            if (data?.fatal) {
+              if (
+                data.type === Hls.ErrorTypes.NETWORK_ERROR &&
+                networkRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
+              ) {
+                networkRecoveryAttempts += 1;
+                const loadPosition = hlsLoadPosition();
+                hls.startLoad(loadPosition);
+                seekVideoTo(loadPosition);
+                return;
+              }
+
+              if (
+                data.type === Hls.ErrorTypes.MEDIA_ERROR &&
+                mediaRecoveryAttempts < HLS_FATAL_RECOVERY_ATTEMPTS
+              ) {
+                mediaRecoveryAttempts += 1;
+                seekVideoTo(hlsLoadPosition());
+                hls.recoverMediaError();
+                return;
+              }
+
+              setPlaybackError("Playback failed because the video segments could not be loaded.");
+            }
+          });
+          cleanupPlayback = () => {
+            video.removeEventListener("canplay", finishRestore);
+            video.removeEventListener("playing", finishRestore);
+            video.removeEventListener("seeking", syncPendingSeek);
+            video.removeEventListener("stalled", recoverHlsPlayback);
+            video.removeEventListener("waiting", recoverHlsPlayback);
+            hls.destroy();
+            hlsRef.current = null;
+          };
+          return;
+        }
+
+        if (video.canPlayType("application/vnd.apple.mpegurl")) {
+          attachNativePlayback();
+        }
+      })
+      .catch(() => {
+        if (active && video.canPlayType("application/vnd.apple.mpegurl")) {
+          attachNativePlayback();
+        }
+      });
+
+    return () => {
+      active = false;
+      capturePlaybackStateFromVideo(video);
+      cleanupPlayback();
+      hlsRef.current = null;
+    };
+  }, [capturePlaybackStateFromVideo, src, videoRef]);
+
+  return { playbackError, capturePlaybackState, playbackIntentRef };
+}

--- a/apps/web/src/hooks/useLibrary.ts
+++ b/apps/web/src/hooks/useLibrary.ts
@@ -1,0 +1,275 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  approveVideoUpload,
+  deleteVideoRecord,
+  getAdminCatalogs,
+  getVideoDetails,
+  listVideos,
+  publishAdminCatalogs,
+  requestErrorMessage,
+  updateVideoPublication,
+  updateVideoVisibility,
+} from "../api/client";
+import type { AdminCatalogs, VideoDetail, VideoSummary, VisibilityUpdate } from "../types";
+import { isActiveStatus } from "../utils/status";
+
+/** Video list with initial load and 5s polling while any video is active. */
+export function useLibraryData(admin: boolean) {
+  const [videos, setVideos] = useState<VideoSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      const data = await listVideos({ admin });
+      setVideos(data);
+      setLoadError("");
+    } catch (err) {
+      setLoadError(requestErrorMessage(err, "Could not load the video catalog."));
+    } finally {
+      setLoading(false);
+    }
+  }, [admin]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (videos.some((video) => isActiveStatus(video.status))) {
+        load();
+      }
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [videos, load]);
+
+  return { videos, setVideos, loading, loadError, load };
+}
+
+/** Route-driven video detail with 5s polling while the video is active. */
+export function useVideoDetail(admin: boolean, routeVideoId: string | undefined) {
+  const [detail, setDetail] = useState<VideoDetail | null>(null);
+  const [detailError, setDetailError] = useState("");
+  const activeDetailId = detail?.id;
+  const activeDetailStatus = detail?.status;
+
+  const loadDetail = useCallback(
+    async (videoId: string) => {
+      setDetailError("");
+      try {
+        const data = await getVideoDetails({ admin, videoId });
+        setDetail(data);
+      } catch (err) {
+        setDetailError(requestErrorMessage(err, "Could not load video details."));
+      }
+    },
+    [admin],
+  );
+
+  useEffect(() => {
+    if (!routeVideoId) {
+      setDetail(null);
+      return;
+    }
+
+    let active = true;
+    setDetailError("");
+    getVideoDetails({ admin, videoId: routeVideoId })
+      .then((data) => {
+        if (active) setDetail(data);
+      })
+      .catch((err) => {
+        if (active) {
+          setDetail(null);
+          setDetailError(requestErrorMessage(err, "Could not load video details."));
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [admin, routeVideoId]);
+
+  useEffect(() => {
+    if (!activeDetailId || !isActiveStatus(activeDetailStatus)) return undefined;
+    const interval = setInterval(async () => {
+      try {
+        const data = await getVideoDetails({ admin, videoId: activeDetailId });
+        setDetail(data);
+        setDetailError("");
+      } catch (err) {
+        setDetailError(requestErrorMessage(err, "Could not refresh video details."));
+      }
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [activeDetailId, activeDetailStatus, admin]);
+
+  return { detail, setDetail, detailError, loadDetail };
+}
+
+/** Admin portable-catalog addresses: load, republish, and copy-to-clipboard. */
+export function useCatalogs(admin: boolean) {
+  const [catalogs, setCatalogs] = useState<AdminCatalogs | null>(null);
+  const [catalogPublishing, setCatalogPublishing] = useState(false);
+  const [catalogCopied, setCatalogCopied] = useState("");
+  const [catalogError, setCatalogError] = useState("");
+
+  const loadCatalogs = useCallback(async () => {
+    if (!admin) return;
+    try {
+      const data = await getAdminCatalogs();
+      setCatalogs(data);
+      setCatalogError("");
+    } catch (err) {
+      setCatalogError(requestErrorMessage(err, "Could not load catalog addresses."));
+    }
+  }, [admin]);
+
+  useEffect(() => {
+    loadCatalogs();
+  }, [loadCatalogs]);
+
+  const republishCatalogs = useCallback(async () => {
+    setCatalogPublishing(true);
+    setCatalogError("");
+    setCatalogCopied("");
+    try {
+      const data = await publishAdminCatalogs();
+      setCatalogs(data);
+    } catch (err) {
+      setCatalogError(requestErrorMessage(err, "Catalog publish failed."));
+    } finally {
+      setCatalogPublishing(false);
+    }
+  }, []);
+
+  const copyAddress = useCallback(async (label: string, address?: string | null) => {
+    if (!address) return;
+    try {
+      await navigator.clipboard.writeText(address);
+      setCatalogCopied(label);
+    } catch {
+      setCatalogError("Could not copy the catalog address.");
+    }
+  }, []);
+
+  return {
+    catalogs,
+    catalogPublishing,
+    catalogCopied,
+    catalogError,
+    loadCatalogs,
+    republishCatalogs,
+    copyAddress,
+  };
+}
+
+interface VideoActionDeps {
+  load: () => Promise<void>;
+  loadCatalogs: () => Promise<void>;
+  onDeleted: (videoId: string) => void;
+  setDetail: (detail: VideoDetail | null) => void;
+  setVideos: React.Dispatch<React.SetStateAction<VideoSummary[]>>;
+}
+
+/** Admin mutations on a video: delete, approve, visibility, publication. */
+export function useVideoActions({
+  load,
+  loadCatalogs,
+  onDeleted,
+  setDetail,
+  setVideos,
+}: VideoActionDeps) {
+  const [approving, setApproving] = useState<string | null>(null);
+  const [publishing, setPublishing] = useState<string | null>(null);
+  const [actionError, setActionError] = useState("");
+
+  const deleteVideo = useCallback(
+    async (videoId: string) => {
+      if (!window.confirm("Delete this video record and remove it from the network catalog?"))
+        return;
+      setActionError("");
+      try {
+        await deleteVideoRecord(videoId);
+        setVideos((prev) => prev.filter((video) => video.id !== videoId));
+        await loadCatalogs();
+        onDeleted(videoId);
+      } catch (err) {
+        setActionError(requestErrorMessage(err, "Delete failed."));
+      }
+    },
+    [loadCatalogs, onDeleted, setVideos],
+  );
+
+  const approveVideo = useCallback(
+    async (videoId: string) => {
+      setApproving(videoId);
+      setActionError("");
+      try {
+        const data = await approveVideoUpload(videoId);
+        setDetail(data);
+        await load();
+        await loadCatalogs();
+      } catch (err) {
+        const message = requestErrorMessage(err, "Approval failed.");
+        setActionError(message);
+        window.alert(message);
+      } finally {
+        setApproving(null);
+      }
+    },
+    [load, loadCatalogs, setDetail],
+  );
+
+  const updateVisibility = useCallback(
+    async (videoId: string, next: VisibilityUpdate) => {
+      setActionError("");
+      try {
+        const data = await updateVideoVisibility(videoId, next);
+        setDetail(data);
+        setVideos((prev) =>
+          prev.map((video) => (video.id === videoId ? { ...video, ...data } : video)),
+        );
+        await loadCatalogs();
+      } catch (err) {
+        setActionError(requestErrorMessage(err, "Visibility update failed."));
+      }
+    },
+    [loadCatalogs, setDetail, setVideos],
+  );
+
+  const updatePublication = useCallback(
+    async (videoId: string, isPublic: boolean) => {
+      setPublishing(videoId);
+      setActionError("");
+      try {
+        const data = await updateVideoPublication(videoId, isPublic);
+        setDetail(data);
+        setVideos((prev) =>
+          prev.map((video) => (video.id === videoId ? { ...video, ...data } : video)),
+        );
+        await loadCatalogs();
+      } catch (err) {
+        setActionError(
+          requestErrorMessage(err, isPublic ? "Publish failed." : "Unpublish failed."),
+        );
+      } finally {
+        setPublishing(null);
+      }
+    },
+    [loadCatalogs, setDetail, setVideos],
+  );
+
+  return {
+    approving,
+    publishing,
+    actionError,
+    setActionError,
+    deleteVideo,
+    approveVideo,
+    updateVisibility,
+    updatePublication,
+  };
+}

--- a/apps/web/src/hooks/useUploadWorkflow.ts
+++ b/apps/web/src/hooks/useUploadWorkflow.ts
@@ -253,8 +253,8 @@ export function useUploadQuote({
           duration_seconds: metaDuration,
           encode_settings: encodeSettings,
           resolutions,
-          source_width: metaWidth,
-          source_height: metaHeight,
+          source_width: metaWidth ?? null,
+          source_height: metaHeight ?? null,
         };
         if (uploadOriginal) {
           quoteRequest.upload_original = true;

--- a/apps/web/src/hooks/useUploadWorkflow.ts
+++ b/apps/web/src/hooks/useUploadWorkflow.ts
@@ -1,0 +1,357 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  isRequestCanceled,
+  requestErrorMessage,
+  requestUploadQuote,
+  uploadVideo,
+} from "../api/client";
+import { RESOLUTION_OPTIONS } from "../constants";
+import type {
+  EncodeSettings,
+  SourceVideoMeta,
+  UploadQuote,
+  UploadQuoteRequest,
+  VideoSummary,
+} from "../types";
+import { classifyResolution, orderedSelection, suggestedSelection } from "../utils/resolutions";
+
+export type VideoCodec = EncodeSettings["video_codec"];
+
+export const DEFAULT_AUDIO_BITRATE_KBPS = 320;
+
+function defaultVideoBitrate(optionKbps: number, codec: VideoCodec): number {
+  if (codec === "hevc") return Math.max(64, Math.round((optionKbps * 0.7) / 50) * 50);
+  return optionKbps;
+}
+
+export function defaultVideoBitrates(codec: VideoCodec): Record<string, number> {
+  return Object.fromEntries(
+    RESOLUTION_OPTIONS.map((option) => [
+      option.value,
+      defaultVideoBitrate(option.defaultVideoBitrateKbps, codec),
+    ]),
+  );
+}
+
+export function buildEncodeSettings(
+  resolutions: string[],
+  videoCodec: VideoCodec,
+  videoBitrates: Record<string, number>,
+  audioBitrateKbps: number,
+): EncodeSettings {
+  const video_bitrate_overrides = Object.fromEntries(
+    resolutions.map((resolution) => [
+      resolution,
+      Math.max(64, Math.round(videoBitrates[resolution] || 0)),
+    ]),
+  );
+  return {
+    video_codec: videoCodec,
+    audio_bitrate_kbps: Math.max(32, Math.round(audioBitrateKbps || DEFAULT_AUDIO_BITRATE_KBPS)),
+    video_bitrate_overrides,
+  };
+}
+
+/**
+ * Upload form state: source file with locally-read metadata, titles,
+ * privacy flags, rendition selection, and encode settings (with default
+ * bitrate migration when the codec changes).
+ */
+export function useUploadForm() {
+  const [file, setFile] = useState<File | null>(null);
+  const [title, setTitle] = useState("");
+  const [desc, setDesc] = useState("");
+  const [showManifestAddress, setShowManifestAddress] = useState(false);
+  const [uploadOriginal, setUploadOriginal] = useState(false);
+  const [publishWhenReady, setPublishWhenReady] = useState(false);
+  const [selected, setSelected] = useState<string[]>(["720p"]);
+  const [videoCodec, setVideoCodec] = useState<VideoCodec>("h264");
+  const [audioBitrateKbps, setAudioBitrateKbps] = useState(DEFAULT_AUDIO_BITRATE_KBPS);
+  const [videoBitrates, setVideoBitrates] = useState<Record<string, number>>(() =>
+    defaultVideoBitrates("h264"),
+  );
+  const [meta, setMeta] = useState<SourceVideoMeta | null>(null);
+
+  const currentProfile = classifyResolution(meta?.width, meta?.height);
+
+  /** Caller validates the file type; this reads metadata and applies defaults. */
+  const inspectFile = useCallback((nextFile: File) => {
+    setFile(nextFile);
+    setTitle((current) => current || nextFile.name.replace(/\.[^.]+$/, ""));
+    setMeta({ loading: true, width: null, height: null, duration: null });
+
+    const objectUrl = URL.createObjectURL(nextFile);
+    const video = document.createElement("video");
+    video.preload = "metadata";
+    video.onloadedmetadata = () => {
+      const nextMeta = {
+        loading: false,
+        width: video.videoWidth,
+        height: video.videoHeight,
+        duration: video.duration,
+        size: nextFile.size,
+      };
+      setMeta(nextMeta);
+      setSelected(suggestedSelection(nextMeta));
+      URL.revokeObjectURL(objectUrl);
+    };
+    video.onerror = () => {
+      setMeta({ loading: false, width: null, height: null, duration: null, size: nextFile.size });
+      setSelected(["720p"]);
+      URL.revokeObjectURL(objectUrl);
+    };
+    video.src = objectUrl;
+  }, []);
+
+  const toggleRes = useCallback((resolution: string) => {
+    setSelected((prev) =>
+      prev.includes(resolution)
+        ? prev.filter((value) => value !== resolution)
+        : [...prev, resolution],
+    );
+  }, []);
+
+  const selectCurrentOnly = useCallback(() => {
+    if (currentProfile) setSelected([currentProfile.value]);
+  }, [currentProfile]);
+
+  const selectAdaptive = useCallback(() => {
+    setSelected(suggestedSelection(meta));
+  }, [meta]);
+
+  /** Switch codec, migrating untouched per-resolution defaults to the new codec's defaults. */
+  const changeCodec = useCallback(
+    (nextCodec: VideoCodec) => {
+      const previousCodec = videoCodec;
+      setVideoCodec(nextCodec);
+      setVideoBitrates((current) => {
+        const previousDefaults = defaultVideoBitrates(previousCodec);
+        const nextDefaults = defaultVideoBitrates(nextCodec);
+        return Object.fromEntries(
+          RESOLUTION_OPTIONS.map((option) => {
+            const currentValue = current[option.value];
+            const nextValue =
+              currentValue === previousDefaults[option.value]
+                ? nextDefaults[option.value]
+                : (currentValue ?? nextDefaults[option.value]);
+            return [option.value, nextValue];
+          }),
+        );
+      });
+    },
+    [videoCodec],
+  );
+
+  const setVideoBitrate = useCallback((resolution: string, kbps: number) => {
+    setVideoBitrates((current) => ({ ...current, [resolution]: kbps }));
+  }, []);
+
+  const reset = useCallback(() => {
+    setFile(null);
+    setTitle("");
+    setDesc("");
+    setShowManifestAddress(false);
+    setUploadOriginal(false);
+    setPublishWhenReady(false);
+    setSelected(["720p"]);
+    setVideoCodec("h264");
+    setAudioBitrateKbps(DEFAULT_AUDIO_BITRATE_KBPS);
+    setVideoBitrates(defaultVideoBitrates("h264"));
+    setMeta(null);
+  }, []);
+
+  return {
+    file,
+    title,
+    setTitle,
+    desc,
+    setDesc,
+    showManifestAddress,
+    setShowManifestAddress,
+    uploadOriginal,
+    setUploadOriginal,
+    publishWhenReady,
+    setPublishWhenReady,
+    selected,
+    videoCodec,
+    audioBitrateKbps,
+    setAudioBitrateKbps,
+    videoBitrates,
+    meta,
+    currentProfile,
+    inspectFile,
+    toggleRes,
+    selectCurrentOnly,
+    selectAdaptive,
+    changeCodec,
+    setVideoBitrate,
+    reset,
+  };
+}
+
+export interface QuoteState {
+  data: UploadQuote | null;
+  error: string;
+  loading: boolean;
+}
+
+const EMPTY_QUOTE: QuoteState = { loading: false, error: "", data: null };
+
+interface UploadQuoteInputs {
+  audioBitrateKbps: number;
+  file: File | null;
+  meta: SourceVideoMeta | null;
+  selected: string[];
+  uploadOriginal: boolean;
+  videoBitrates: Record<string, number>;
+  videoCodec: VideoCodec;
+}
+
+/**
+ * Debounced upload price quote: refetches 250ms after any settings change,
+ * canceling in-flight requests. `resetQuote` clears the current quote
+ * immediately so a stale price never lingers during the debounce window.
+ */
+export function useUploadQuote({
+  file,
+  meta,
+  selected,
+  videoCodec,
+  videoBitrates,
+  audioBitrateKbps,
+  uploadOriginal,
+}: UploadQuoteInputs) {
+  const [quote, setQuote] = useState<QuoteState>(EMPTY_QUOTE);
+
+  const resetQuote = useCallback(() => {
+    setQuote(EMPTY_QUOTE);
+  }, []);
+
+  const metaDuration = meta?.duration;
+  const metaWidth = meta?.width;
+  const metaHeight = meta?.height;
+
+  useEffect(() => {
+    if (!file || !metaDuration || !selected.length) {
+      setQuote(EMPTY_QUOTE);
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      const resolutions = orderedSelection(selected);
+      setQuote({ loading: true, error: "", data: null });
+      try {
+        const encodeSettings = buildEncodeSettings(
+          resolutions,
+          videoCodec,
+          videoBitrates,
+          audioBitrateKbps,
+        );
+        const quoteRequest: UploadQuoteRequest = {
+          duration_seconds: metaDuration,
+          encode_settings: encodeSettings,
+          resolutions,
+          source_width: metaWidth,
+          source_height: metaHeight,
+        };
+        if (uploadOriginal) {
+          quoteRequest.upload_original = true;
+          quoteRequest.source_size_bytes = file.size;
+        }
+        const data = await requestUploadQuote(quoteRequest, controller.signal);
+        setQuote({ loading: false, error: "", data });
+      } catch (err) {
+        if (isRequestCanceled(err)) return;
+        setQuote({
+          loading: false,
+          error: requestErrorMessage(err, "Could not get upload price quote"),
+          data: null,
+        });
+      }
+    }, 250);
+
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [
+    audioBitrateKbps,
+    file,
+    metaDuration,
+    metaWidth,
+    metaHeight,
+    selected,
+    uploadOriginal,
+    videoBitrates,
+    videoCodec,
+  ]);
+
+  return { quote, resetQuote };
+}
+
+interface UploadSubmitArgs {
+  form: ReturnType<typeof useUploadForm>;
+  onSuccess: (video: VideoSummary) => void;
+  quote: QuoteState;
+}
+
+/** Multipart upload submission with validation and progress reporting. */
+export function useUploadSubmit({ form, quote, onSuccess }: UploadSubmitArgs) {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState("");
+  const [progress, setProgress] = useState(0);
+
+  const submit = useCallback(async () => {
+    const { file, title, desc, selected, meta } = form;
+    if (!file) return setError("Drop or choose a video file first.");
+    if (!title.trim()) return setError("Please enter a title.");
+    if (!selected.length) return setError("Select at least one resolution.");
+    if (meta?.duration && !quote.data) {
+      return setError("Waiting for an upload price quote before starting.");
+    }
+
+    setError("");
+    setUploading(true);
+    setProgress(0);
+
+    const resolutionsToUpload = orderedSelection(selected);
+
+    const fd = new FormData();
+    const encodeSettings = buildEncodeSettings(
+      resolutionsToUpload,
+      form.videoCodec,
+      form.videoBitrates,
+      form.audioBitrateKbps,
+    );
+    fd.append("file", file);
+    fd.append("title", title.trim());
+    fd.append("description", desc.trim());
+    fd.append("resolutions", resolutionsToUpload.join(","));
+    fd.append("show_original_filename", "false");
+    fd.append("show_manifest_address", form.showManifestAddress ? "true" : "false");
+    fd.append("upload_original", form.uploadOriginal ? "true" : "false");
+    fd.append("publish_when_ready", form.publishWhenReady ? "true" : "false");
+    fd.append("video_codec", encodeSettings.video_codec);
+    fd.append("audio_bitrate_kbps", String(encodeSettings.audio_bitrate_kbps));
+    fd.append("video_bitrate_overrides", JSON.stringify(encodeSettings.video_bitrate_overrides));
+
+    try {
+      const data = await uploadVideo(fd, (progressEvent) => {
+        if (progressEvent.total) {
+          setProgress(Math.round((progressEvent.loaded / progressEvent.total) * 100));
+        }
+      });
+      setProgress(0);
+      onSuccess(data);
+    } catch (err) {
+      setError(requestErrorMessage(err, "Upload failed"));
+    } finally {
+      setUploading(false);
+    }
+    return undefined;
+  }, [form, onSuccess, quote.data]);
+
+  return { uploading, error, setError, progress, submit };
+}


### PR DESCRIPTION
## Summary

Phase 5 of `docs/IMPROVEMENT_PLAN.md`. Stacked on #124. One commit per component, then lazy loading.

| Component | Before | After |
|---|---|---|
| `VideoPlayer.tsx` | 489 lines | 110-line composition + `useHlsPlayer` (playback lifecycle, moved wholesale), `useControlsVisibility`, `player/QualityMenu` |
| `Library.tsx` | 490 lines | ~190-line composition + `useLibraryData`/`useVideoDetail`/`useCatalogs`/`useVideoActions` hooks, `library/{CatalogPanel,VideoDetailPane}` |
| `UploadPanel.tsx` | 575 lines | ~220-line composition + `useUploadForm` (codec bitrate-default migration), `useUploadQuote` (debounced, abortable), `useUploadSubmit`, `upload/{FileDropZone,EncodeSettingsFields,UploadQuoteSummary}` |

**Route splitting:** `React.lazy` + `Suspense` for Library and UploadPanel defers those chunks — and the 500K hls.js chunk — from the initial bundle. Entry JS drops from ~740K to ~230K (index 20K + react 140K + vendor 48K + router 20K).

**Test adjustments:** upload tests now install fake timers *after* the lazy page loads (Vitest's first dynamic import needs real time) via a new `findFileInput` helper. The e2e had a pre-existing race — clicking submit inside the quote debounce window — now made deterministic by waiting for the priced quote.

## Verification

- All 39 unit tests pass unchanged (playback/admin/upload suites are the behavioral contract) ✓
- Coverage 79.4% stmts / 70.2% branches / 78.8% funcs / 81.4% lines — above the 70% gates ✓
- lint, format:check, tsc build ✓; chunk report confirms hls/Library/UploadPanel split out of entry ✓
- **Runtime**: `make up-local` + `make smoke-local` ✓ and **Playwright e2e** (real browser: login → upload → approve → publish → HLS playback) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)