### PR TITLE
Phase 6: cargo-chef builds, pinned Foundry, CI e2e job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,3 +26,11 @@ apps/web/dist/
 apps/web/build/
 apps/web/coverage/
 build/
+
+# Not consumed by any root-context (Rust/devnet) image build
+apps/
+docs/
+deploy/monitoring/
+deploy/nginx/
+testvids/
+.claude/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 6 * * *"
 
 jobs:
   rust-workspace:
@@ -248,3 +251,62 @@ jobs:
           ignore-unfixed: true
           severity: CRITICAL,HIGH
           exit-code: "1"
+
+  e2e:
+    name: End-to-end Playwright against local devnet
+    # Too heavy per-PR: full stack boot + real transcode pipeline. Runs on main
+    # pushes, nightly, and on demand. Treat as advisory until a week of green.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare env file
+        run: cp .env.local.example .env.local
+
+      - name: Boot stack with prebuilt devnet image
+        run: docker compose --env-file .env.local -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml -f deploy/docker-compose.ci.yml up -d --build --wait
+        timeout-minutes: 30
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: apps/web
+
+      - name: Install Playwright browser
+        run: npx playwright install chromium --with-deps
+        working-directory: apps/web
+
+      - name: Generate test fixture
+        run: |
+          sudo apt-get update && sudo apt-get install -y ffmpeg
+          ffmpeg -hide_banner -loglevel error -y \
+            -f lavfi -i testsrc=size=640x360:rate=24 \
+            -f lavfi -i sine=frequency=880:sample_rate=44100 \
+            -t 4 -shortest -c:v libx264 -preset ultrafast -pix_fmt yuv420p \
+            -c:a aac -movflags +faststart /tmp/e2e-sample.mp4
+
+      - name: Run Playwright e2e
+        run: npm run e2e
+        working-directory: apps/web
+        env:
+          E2E_BASE_URL: http://localhost
+          E2E_VIDEO_PATH: /tmp/e2e-sample.mp4
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+
+      - name: Dump compose logs
+        if: failure()
+        run: docker compose --env-file .env.local -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml -f deploy/docker-compose.ci.yml logs --tail 200

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,7 @@ testvids/
 testvids/**
 testvids/*
 ChatGPT Image Apr 29, 2026 at 02_45_59 PM.png
+
+# Playwright artifacts
+apps/web/test-results/
+apps/web/playwright-report/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install-react install-desktop test test-rust test-rust-workspace test-rust-stream test-rust-admin test-rust-db test-antd clippy-rust clippy-rust-workspace clippy-rust-stream clippy-rust-admin clippy-antd fmt-rust fmt-react deny-rust compose-config up-local up-local-full up-prod down-local down-prod logs logs-prod logs-monitoring devbench-build devbench-up devbench-down devbench-restart devbench-status devbench-shell devbench-exec backup-production restore-production lint-react test-react coverage-react build-react stage-tauri-sidecars build-tauri smoke-local smoke-local-restart smoke-local-large-original audit-rust audit-react audit-trivy audit ci
+.PHONY: help install-react install-desktop test test-rust test-rust-workspace test-rust-stream test-rust-admin test-rust-db test-antd clippy-rust clippy-rust-workspace clippy-rust-stream clippy-rust-admin clippy-antd fmt-rust fmt-react deny-rust compose-config up-local up-local-full up-prod down-local down-prod logs logs-prod logs-monitoring devbench-build devbench-up devbench-down devbench-restart devbench-status devbench-shell devbench-exec backup-production restore-production lint-react test-react coverage-react build-react stage-tauri-sidecars build-tauri smoke-local smoke-local-restart e2e-local smoke-local-large-original audit-rust audit-react audit-trivy audit ci
 
 NPM ?= npm
 CARGO ?= cargo
@@ -53,6 +53,7 @@ help:
 	@echo "  make smoke-local     Run an end-to-end local devnet smoke test"
 	@echo "  make smoke-local-restart Run smoke test with rust_admin restart recovery"
 	@echo "  make smoke-local-large-original Run smoke test with >16MB original source upload"
+	@echo "  make e2e-local       Run the Playwright e2e against a running local stack"
 	@echo "  make audit-rust      Run cargo audit if installed"
 	@echo "  make audit-react     Run npm production audit"
 	@echo "  make audit-trivy     Run Trivy filesystem scan if installed"
@@ -189,6 +190,9 @@ test-react:
 
 coverage-react:
 	cd apps/web && CI=true $(NPM) run test:coverage
+
+e2e-local:
+	cd apps/web && E2E_BASE_URL=http://localhost $(NPM) run e2e
 
 smoke-local:
 	scripts/smoke-local-devnet.sh

--- a/crates/antd_service/Dockerfile
+++ b/crates/antd_service/Dockerfile
@@ -1,40 +1,37 @@
-# ── Stage 1: Build the Autonomi 2.0 compatibility gateway ────────────────────
-FROM rust:1.96-slim-bookworm AS builder
+# ── Stage 1: Chef (shared toolchain + cargo-chef, layer-identical across services) ──
+FROM rust:1.96-slim-bookworm AS chef
 
 RUN apt-get update && apt-get install -y \
     build-essential \
     git \
-    libssl-dev \
     liblzma-dev \
     perl \
     pkg-config \
+    libssl-dev \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
+RUN cargo install cargo-chef --locked
+
 WORKDIR /app
 
+# ── Stage 2: Plan (recipe.json only changes when dependencies change) ─────────
+FROM chef AS planner
+
 COPY Cargo.toml Cargo.lock ./
-COPY crates/common/Cargo.toml crates/common/Cargo.toml
-COPY crates/rust_admin/Cargo.toml crates/rust_admin/Cargo.toml
-COPY crates/rust_stream/Cargo.toml crates/rust_stream/Cargo.toml
-COPY crates/antd_service/Cargo.toml crates/antd_service/Cargo.toml
-COPY crates/launcher_core/Cargo.toml crates/launcher_core/Cargo.toml
-COPY crates/standalone_launcher/Cargo.toml crates/standalone_launcher/Cargo.toml
-RUN mkdir -p crates/common/src crates/rust_admin/src crates/rust_stream/src crates/antd_service/src crates/launcher_core/src crates/standalone_launcher/src && \
-    echo "" > crates/common/src/lib.rs && \
-    echo "fn main(){}" > crates/rust_admin/src/main.rs && \
-    echo "fn main(){}" > crates/rust_stream/src/main.rs && \
-    echo "fn main(){}" > crates/antd_service/src/main.rs && \
-    echo "" > crates/launcher_core/src/lib.rs && \
-    echo "fn main(){}" > crates/standalone_launcher/src/main.rs && \
-    cargo build --release -p antd
+COPY crates/ crates/
+RUN cargo chef prepare --recipe-path recipe.json
 
-COPY crates/common/src crates/common/src
-COPY crates/launcher_core/src crates/launcher_core/src
-COPY crates/antd_service/src crates/antd_service/src
-RUN touch crates/common/src/lib.rs crates/launcher_core/src/lib.rs crates/antd_service/src/main.rs && cargo build --release -p antd
+# ── Stage 3: Build (dependency layer cached on recipe content) ────────────────
+FROM chef AS builder
 
-# ── Stage 2: Minimal runtime ──────────────────────────────────────────────────
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p antd
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+RUN cargo build --release -p antd
+
+# ── Stage 4: Runtime ──────────────────────────────────────────────────
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \

--- a/crates/rust_admin/Dockerfile
+++ b/crates/rust_admin/Dockerfile
@@ -1,38 +1,37 @@
-# ── Stage 1: Build ────────────────────────────────────────────────────────────
-FROM rust:1.96-slim-bookworm AS builder
+# ── Stage 1: Chef (shared toolchain + cargo-chef, layer-identical across services) ──
+FROM rust:1.96-slim-bookworm AS chef
 
 RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    liblzma-dev \
+    perl \
     pkg-config \
     libssl-dev \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
+RUN cargo install cargo-chef --locked
+
 WORKDIR /app
 
-# Cache dependencies before copying source
+# ── Stage 2: Plan (recipe.json only changes when dependencies change) ─────────
+FROM chef AS planner
+
 COPY Cargo.toml Cargo.lock ./
-COPY crates/common/Cargo.toml crates/common/Cargo.toml
-COPY crates/rust_admin/Cargo.toml crates/rust_admin/Cargo.toml
-COPY crates/rust_stream/Cargo.toml crates/rust_stream/Cargo.toml
-COPY crates/antd_service/Cargo.toml crates/antd_service/Cargo.toml
-COPY crates/launcher_core/Cargo.toml crates/launcher_core/Cargo.toml
-COPY crates/standalone_launcher/Cargo.toml crates/standalone_launcher/Cargo.toml
-RUN mkdir -p crates/common/src crates/rust_admin/src crates/rust_stream/src crates/antd_service/src crates/launcher_core/src crates/standalone_launcher/src && \
-    echo "" > crates/common/src/lib.rs && \
-    echo "fn main(){}" > crates/rust_admin/src/main.rs && \
-    echo "fn main(){}" > crates/rust_stream/src/main.rs && \
-    echo "fn main(){}" > crates/antd_service/src/main.rs && \
-    echo "" > crates/launcher_core/src/lib.rs && \
-    echo "fn main(){}" > crates/standalone_launcher/src/main.rs && \
-    cargo build --release -p rust_admin
+COPY crates/ crates/
+RUN cargo chef prepare --recipe-path recipe.json
 
-COPY crates/common/src crates/common/src
-COPY crates/launcher_core/src crates/launcher_core/src
-COPY crates/rust_admin/migrations crates/rust_admin/migrations
-COPY crates/rust_admin/src crates/rust_admin/src
-RUN touch crates/common/src/lib.rs crates/launcher_core/src/lib.rs crates/rust_admin/src/main.rs && cargo build --release -p rust_admin
+# ── Stage 3: Build (dependency layer cached on recipe content) ────────────────
+FROM chef AS builder
 
-# ── Stage 2: Runtime ──────────────────────────────────────────────────────────
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p rust_admin
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+RUN cargo build --release -p rust_admin
+
+# ── Stage 4: Runtime ──────────────────────────────────────────────────────────
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \

--- a/crates/rust_stream/Dockerfile
+++ b/crates/rust_stream/Dockerfile
@@ -1,37 +1,37 @@
-# ── Stage 1: Build ────────────────────────────────────────────────────────────
-FROM rust:1.96-slim-bookworm AS builder
+# ── Stage 1: Chef (shared toolchain + cargo-chef, layer-identical across services) ──
+FROM rust:1.96-slim-bookworm AS chef
 
 RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    liblzma-dev \
+    perl \
     pkg-config \
     libssl-dev \
     protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
+RUN cargo install cargo-chef --locked
+
 WORKDIR /app
 
-# Cache dependencies before copying source
+# ── Stage 2: Plan (recipe.json only changes when dependencies change) ─────────
+FROM chef AS planner
+
 COPY Cargo.toml Cargo.lock ./
-COPY crates/common/Cargo.toml crates/common/Cargo.toml
-COPY crates/rust_admin/Cargo.toml crates/rust_admin/Cargo.toml
-COPY crates/rust_stream/Cargo.toml crates/rust_stream/Cargo.toml
-COPY crates/antd_service/Cargo.toml crates/antd_service/Cargo.toml
-COPY crates/launcher_core/Cargo.toml crates/launcher_core/Cargo.toml
-COPY crates/standalone_launcher/Cargo.toml crates/standalone_launcher/Cargo.toml
-RUN mkdir -p crates/common/src crates/rust_admin/src crates/rust_stream/src crates/antd_service/src crates/launcher_core/src crates/standalone_launcher/src && \
-    echo "" > crates/common/src/lib.rs && \
-    echo "fn main(){}" > crates/rust_admin/src/main.rs && \
-    echo "fn main(){}" > crates/rust_stream/src/main.rs && \
-    echo "fn main(){}" > crates/antd_service/src/main.rs && \
-    echo "" > crates/launcher_core/src/lib.rs && \
-    echo "fn main(){}" > crates/standalone_launcher/src/main.rs && \
-    cargo build --release -p rust_stream
+COPY crates/ crates/
+RUN cargo chef prepare --recipe-path recipe.json
 
-COPY crates/common/src crates/common/src
-COPY crates/launcher_core/src crates/launcher_core/src
-COPY crates/rust_stream/src crates/rust_stream/src
-RUN touch crates/common/src/lib.rs crates/launcher_core/src/lib.rs crates/rust_stream/src/main.rs && cargo build --release -p rust_stream
+# ── Stage 3: Build (dependency layer cached on recipe content) ────────────────
+FROM chef AS builder
 
-# ── Stage 2: Runtime ──────────────────────────────────────────────────────────
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p rust_stream
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+RUN cargo build --release -p rust_stream
+
+# ── Stage 4: Runtime ──────────────────────────────────────────────────────────
 FROM gcr.io/distroless/cc-debian12:nonroot
 
 COPY --from=builder /app/target/release/rust_stream /usr/local/bin/rust_stream

--- a/deploy/autonomi_devnet/Dockerfile
+++ b/deploy/autonomi_devnet/Dockerfile
@@ -66,13 +66,16 @@ RUN apt-get update && apt-get install -y \
     libssl3 \
     && rm -rf /var/lib/apt/lists/*
 
+# Pinned: a live "latest release" lookup made builds unreproducible and
+# subject to GitHub API rate limits. Bump deliberately.
+ARG FOUNDRY_TAG=v1.4.1
+
 RUN ARCH="$(dpkg --print-architecture)" && \
     case "$ARCH" in \
       amd64) FOUNDRY_ARCH="amd64" ;; \
       arm64) FOUNDRY_ARCH="arm64" ;; \
       *) echo "Unsupported architecture: $ARCH" >&2; exit 1 ;; \
     esac && \
-    FOUNDRY_TAG="$(curl -fsSL https://api.github.com/repos/foundry-rs/foundry/releases/latest | jq -r '.tag_name')" && \
     curl -fsSLo /tmp/foundry.tar.gz \
       "https://github.com/foundry-rs/foundry/releases/download/${FOUNDRY_TAG}/foundry_${FOUNDRY_TAG}_linux_${FOUNDRY_ARCH}.tar.gz" && \
     tar -xzf /tmp/foundry.tar.gz -C /usr/local/bin anvil forge cast chisel && \

--- a/deploy/docker-compose.ci.yml
+++ b/deploy/docker-compose.ci.yml
@@ -1,0 +1,7 @@
+# CI overlay: use the prebuilt devnet image from GHCR instead of the 30+ minute
+# from-source build. Apply after docker-compose.local.yml:
+#   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml -f deploy/docker-compose.ci.yml ...
+services:
+  antd:
+    image: "${DEVNET_IMAGE:-ghcr.io/wydileie/autonomi-video-management-autonomi-devnet:latest}"
+    build: !reset null


### PR DESCRIPTION
## Summary

Phase 6 of `docs/IMPROVEMENT_PLAN.md`. Stacked on #125.

### Docker
- **cargo-chef** replaces the dummy-stub dependency caching in all three Rust Dockerfiles. The chef stage is byte-identical across services so BuildKit shares its layers; dependencies cook against `recipe.json`, so the cache key is the dependency set — not file timestamps. **Verified:** a one-line source change leaves `cargo chef cook` CACHED and recompiles only workspace crates.
- **Foundry pinned** (`ARG FOUNDRY_TAG=v1.4.1`) in the devnet image — the previous live `releases/latest` GitHub API call was unreproducible and rate-limit-prone. The ant-sdk/ant-node clones were already ref-pinned.
- **antd_service stays debian-slim** (plan allowed fallback): its ant-* native dependencies need `libssl3` at runtime, so distroless/cc would require hand-copying OpenSSL libraries.
- `.dockerignore` now excludes `apps/`, `docs/`, monitoring, testvids, and `.claude/` from root-context builds.

### CI
- New **e2e job**: boots the full stack using the new `deploy/docker-compose.ci.yml` overlay (devnet swapped to the prebuilt GHCR image, skipping its 30+ min source build), generates an ffmpeg fixture, and runs the Playwright suite. Runs on main pushes + nightly cron + manual dispatch; uploads the Playwright report and compose logs on failure. Advisory until it has a green track record.
- `make e2e-local` runs the same suite against a locally running stack.

## Verification

- `make compose-config`: all render targets + the new CI overlay (verified image swap and `build: !reset null`) ✓
- Full image rebuild with chef + `make up-local` + `make smoke-local` end-to-end ✓
- Cache-hit proof: source-only change → cook layer CACHED ✓
- Foundry v1.4.1 release asset verified downloadable ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)