### PR TITLE
Update Autonomi service dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "ant-core"
-version = "0.2.8"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36a0c4c5bf384aa92f635e3cd979b23a330cbcfbe22971be80a5c2894893741"
+checksum = "e36231d66cfe293ecfe35458fd5b031fe1faa71d786df225f71bb406ba02abc5"
 dependencies = [
  "ant-protocol",
  "async-stream",
@@ -867,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "ant-node"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e6e8f726bdc4fa307c6b4732b4b80233d231fa8cbedd6048fde6a8996a7a29"
+checksum = "3f7f5de9683a7ce865dbc34eb51356fc748a0ee5b274e4fb343aec4de5dc3c81"
 dependencies = [
  "ant-protocol",
  "blake3",
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "ant-protocol"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61260c89bbc0039e0643f3e2ec79b1c17aee9d81b58d7edbc52314689489f39"
+checksum = "5b665880152b4e124094acc1faaff5f20a275594e6364b8a729b50f3bc326674"
 dependencies = [
  "blake3",
  "bytes",
@@ -2585,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "evmlib"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd96cf24017cd31cd422c80de3078a821b7884a5b1feb00087e98209326c676"
+checksum = "8da0d9ad5b5cab92cc92ddac9afb884f86b226340caf17f6e5c41d51175dcaa1"
 dependencies = [
  "alloy",
  "ant-merkle",
@@ -5570,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-core"
-version = "0.26.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8cc1b7f59f97d018760ff150bbb4f217197c41622b83f7085c9cf0424b736e"
+checksum = "5d9c05644c46b8de670aa5c8eea037b90731f1f204e8aa5d8a2f03496d740401"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5685,9 +5685,9 @@ dependencies = [
 
 [[package]]
 name = "saorsa-transport"
-version = "0.35.0"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621d0a207914a8fd6453f25e4bcc369914cbfaf59a2857e898c079b95f52f5bb"
+checksum = "3c39d5524d6c886e402d9024d927988ea4e80b0105ce04ff03c89191579d2ada"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6610,7 +6610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/README.md
+++ b/README.md
@@ -620,9 +620,9 @@ autonomi-video-management/
 
 ---
 
-## Autonomi SDK 2.0
+## Autonomi gateway architecture
 
-This project uses the [ant-sdk](https://github.com/WithAutonomi/ant-sdk) (v2.0) architecture:
+The application stack follows the [ant-sdk](https://github.com/WithAutonomi/ant-sdk) v2.0 gateway architecture. Its Compose image builds the in-repository `antd` gateway against the pinned Autonomi crates, while the devcontainer separately installs the upstream SDK daemon, client, and MCP tooling for development:
 
 - **`antd`** is a local gateway daemon (Rust) that handles all network connectivity, EVM payments, and content addressing. Your application code never touches the Autonomi peer network directly.
 - **Admin writes** — `rust_admin` talks to the `antd` REST API for quotes, uploads, wallet approval, and catalog/manifest writes.

--- a/crates/antd_service/Cargo.toml
+++ b/crates/antd_service/Cargo.toml
@@ -10,13 +10,13 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
-ant-core = "=0.2.8"
-ant-node = "=0.14.0"
+ant-core = "=0.4.0"
+ant-node = "=0.14.3"
 autvid_common = { path = "../common" }
 axum.workspace = true
 base64.workspace = true
 bytes.workspace = true
-evmlib = "=0.8.1"
+evmlib = "=0.9.0"
 hex = "0.4"
 futures-util = "0.3"
 rmp-serde = "1"

--- a/deploy/autonomi_devnet/Dockerfile
+++ b/deploy/autonomi_devnet/Dockerfile
@@ -1,8 +1,9 @@
 # ── Stage 1: Build local Autonomi devnet tooling ─────────────────────────────
 FROM rust:1.96-slim-bookworm AS builder
 
-ARG AUTONOMI_ANT_SDK_REF=v0.10.0
-ARG AUTONOMI_ANT_NODE_REF=v0.13.0
+# Keep ant-devnet aligned with the app gateway's Autonomi protocol stack so
+# smoke tests exercise compatible peers.
+ARG AUTONOMI_ANT_NODE_REF=v0.14.3
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -15,13 +16,6 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
-
-RUN git clone https://github.com/WithAutonomi/ant-sdk.git ant-sdk && \
-    cd ant-sdk && \
-    git checkout "$AUTONOMI_ANT_SDK_REF" && \
-    cd antd && \
-    cargo build --release && \
-    cp target/release/antd /usr/local/bin/antd
 
 RUN git clone https://github.com/WithAutonomi/ant-node.git ant-node && \
     cd ant-node && \
@@ -81,12 +75,14 @@ RUN ARCH="$(dpkg --print-architecture)" && \
     tar -xzf /tmp/foundry.tar.gz -C /usr/local/bin anvil forge cast chisel && \
     rm -f /tmp/foundry.tar.gz
 
-COPY --from=builder /usr/local/bin/antd /usr/local/bin/antd
 COPY --from=builder /usr/local/bin/ant-devnet /usr/local/bin/ant-devnet
 COPY --from=builder /usr/local/bin/autvid-antd-gateway /usr/local/bin/autvid-antd-gateway
 COPY deploy/autonomi_devnet/start-local-devnet.sh /usr/local/bin/start-local-devnet.sh
 
-RUN mkdir -p /data && \
+# Preserve the traditional antd command for debug/healthcheck use while routing
+# it to the in-repo gateway that matches this lockfile.
+RUN ln -s /usr/local/bin/autvid-antd-gateway /usr/local/bin/antd && \
+    mkdir -p /data && \
     useradd --system --uid 10001 --create-home --shell /usr/sbin/nologin appuser && \
     chown -R appuser:appuser /data /home/appuser && \
     chmod +x /usr/local/bin/start-local-devnet.sh

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -106,7 +106,7 @@ Verify: `npm run lint && npm run format:check && npm test && npm run test:covera
 ## Phase 6 — Docker & CI optimization
 
 - cargo-chef in the 3 Rust Dockerfiles (chef → planner → cook recipe → build; root context; tighten `.dockerignore` to exclude `apps/`, `deploy/monitoring`, `docs/` so the planner stage doesn't invalidate spuriously)
-- `deploy/autonomi_devnet/Dockerfile`: pin Foundry via `ARG FOUNDRY_VERSION` (delete the live GitHub API "latest" call); pin ant-sdk/ant-node clones to tags/SHAs via ARGs
+- `deploy/autonomi_devnet/Dockerfile`: pin Foundry via `ARG FOUNDRY_VERSION` (delete the live GitHub API "latest" call); pin the remaining ant-node clone to a tag/SHA via an ARG
 - antd_service runtime: attempt distroless/cc + `liblzma.so.5` copy (all crates use rustls, no libssl needed); fall back to debian-slim if smoke fails. rust_admin stays debian-slim (ffmpeg)
 - New CI `e2e` job (main pushes + nightly schedule + workflow_dispatch): committed `deploy/docker-compose.ci.yml` overriding devnet to prebuilt GHCR image; compose up --wait; `npx playwright install chromium --with-deps`; `E2E_BASE_URL=http://localhost npm run e2e`; upload report + compose logs on failure. Verify `.env.local.example` boots the stack (add committed `.env.ci` if placeholders block boot). Mark non-required initially; promote after a week of green nightlies
 - Makefile `e2e-local` target


### PR DESCRIPTION
## Summary
- Update the Autonomi gateway dependency set together: `ant-core =0.4.0`, `ant-node =0.14.3`, and `evmlib =0.9.0`.
- Regenerate the lockfile so `ant-protocol` resolves coherently to `2.3.0` with the matching `saorsa-*` updates.
- Align the local devnet image with `ant-node v0.14.3`, remove the stale upstream `ant-sdk` daemon build, and keep `/usr/local/bin/antd` as a compatibility symlink to the in-repo gateway.

## Dependabot context
- Supersedes the blocked Autonomi dependency PRs #128, #131, and #136 by updating the interdependent Rust crates as one set.
- The separate ESLint 10 PR #130 is not included here; local investigation found the current stable `eslint-plugin-react` peer range blocks that update.

## Validation
- `make fmt-rust`
- `make test-antd`
- `make test-rust`
- `make clippy-rust`
- `make deny-rust` (warnings only; final result ok)
- `docker build -t autvid-antd-service:codex -f ./crates/antd_service/Dockerfile .`
- `docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.70.0 image --ignore-unfixed --severity CRITICAL,HIGH --exit-code 1 autvid-antd-service:codex`
- `make compose-config`
- `make up-local`
- `make smoke-local` (quote, upload, final approval, public catalog visibility, and playlist/segment fetches)
- `docker compose --env-file .env.local -f deploy/docker-compose.yml -f deploy/docker-compose.local.yml exec -T antd /usr/local/bin/antd --healthcheck 127.0.0.1:8082 /livez`
- `make down-local`
- `git diff --check`

## Review notes
- Claude CLI review was run with the available `opus` model alias. It reported no blocking issues; its maintainability findings were addressed by removing the unused SDK daemon build, checking for stale `AUTONOMI_ANT_SDK_REF` references, and documenting the `antd` compatibility symlink.

## Residual risk
- `cargo-llvm-cov` is not installed locally, so the Rust coverage job was not reproduced here.
