### PR TITLE
Fix CI audit and frontend runtime failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   rust-workspace:
@@ -227,6 +227,7 @@ jobs:
         with:
           scan-type: fs
           scan-ref: .
+          trivyignores: .trivyignore.yaml
           ignore-unfixed: true
           severity: CRITICAL,HIGH
           exit-code: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,16 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
   schedule:
     - cron: "17 6 * * *"
+
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   rust-workspace:
@@ -213,7 +219,7 @@ jobs:
         working-directory: apps/web
 
       - name: Run npm production audit
-        run: npm audit --omit=dev
+        run: npm run audit:prod
         working-directory: apps/web
 
       - name: Run Trivy filesystem scan

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,8 @@
+vulnerabilities:
+  - id: GHSA-qwww-vcr4-c8h2
+    paths:
+      - apps/web/package-lock.json
+    purls:
+      - pkg:npm/react-router@7.18.2
+    statement: The application is a BrowserRouter SPA and does not use the affected unstable RSC APIs.
+    expired_at: 2026-12-31

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4524,9 +4524,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/apps/web/e2e/upload-playback.spec.ts
+++ b/apps/web/e2e/upload-playback.spec.ts
@@ -23,7 +23,13 @@ async function csrfHeader(page: Page) {
 }
 
 test("login, upload, approve, publish, and play an HLS segment", async ({ page }) => {
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
   await page.goto("/login");
+  await expect(page.getByLabel("Username")).toBeVisible({ timeout: 15_000 });
+  expect(pageErrors, `page errors: ${pageErrors.map((error) => error.message).join("; ")}`).toEqual(
+    [],
+  );
   await page.getByLabel("Username").fill(adminUsername);
   await page.getByLabel("Password").fill(adminPassword);
   await page.getByRole("button", { name: "Sign in" }).click();
@@ -87,4 +93,7 @@ test("login, upload, approve, publish, and play an HLS segment", async ({ page }
   const segment = await page.request.get(segmentUrl);
   expect(segment.ok()).toBeTruthy();
   expect((await segment.body()).byteLength).toBeGreaterThan(0);
+  expect(pageErrors, `page errors: ${pageErrors.map((error) => error.message).join("; ")}`).toEqual(
+    [],
+  );
 });

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -16,6 +16,13 @@ export default tseslint.config(
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
+    files: ["scripts/**/*.mjs"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      globals: globals.node,
+    },
+  },
+  {
     files: ["src/**/*.{ts,tsx}", "vite.config.mts"],
     languageOptions: {
       ecmaVersion: "latest",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -13,7 +13,7 @@
         "hls.js": "^1.5.13",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.18.2"
+        "react-router-dom": "7.18.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,7 @@
     "hls.js": "^1.5.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.18.2"
+    "react-router-dom": "7.18.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
@@ -32,12 +32,13 @@
   },
   "scripts": {
     "start": "vite --host 0.0.0.0",
+    "audit:prod": "node scripts/audit-production.mjs",
     "build": "tsc --noEmit && vite build",
     "e2e": "playwright test",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint .",
-    "test": "vitest run",
+    "test": "node --test scripts/*.node-test.mjs && vitest run",
     "test:coverage": "vitest run --coverage"
   }
 }

--- a/apps/web/scripts/audit-production.mjs
+++ b/apps/web/scripts/audit-production.mjs
@@ -7,7 +7,11 @@ export const allowedAdvisories = new Map([
     new Map([
       [
         "GHSA-qwww-vcr4-c8h2",
-        "Only affects unstable React Router RSC APIs, which this SPA does not use; remove when 8.3.0 is published on npm.",
+        {
+          expiresOn: "2026-12-31",
+          reason:
+            "Only affects unstable React Router RSC APIs, which this SPA does not use; remove when 8.3.0 is published on npm.",
+        },
       ],
     ]),
   ],
@@ -17,7 +21,11 @@ function advisoryId(via) {
   return via.url?.match(/GHSA-[a-z0-9-]+/i)?.[0];
 }
 
-export function findUnapprovedPackages(vulnerabilities, allowlist = allowedAdvisories) {
+export function findUnapprovedPackages(
+  vulnerabilities,
+  allowlist = allowedAdvisories,
+  asOf = new Date().toISOString().slice(0, 10),
+) {
   const memo = new Map();
 
   function hasUnapprovedAdvisory(packageName, visiting = new Set()) {
@@ -36,7 +44,10 @@ export function findUnapprovedPackages(vulnerabilities, allowlist = allowedAdvis
       }
 
       const id = advisoryId(via);
-      return !id || !allowlist.get(packageName)?.has(id);
+      const approval = id && allowlist.get(packageName)?.get(id);
+      return (
+        !approval || !/^\d{4}-\d{2}-\d{2}$/.test(approval.expiresOn) || approval.expiresOn < asOf
+      );
     });
 
     memo.set(packageName, unapproved);
@@ -97,8 +108,8 @@ function run() {
 
   console.warn("npm audit reported only explicitly reviewed production advisories:");
   for (const [packageName, advisories] of allowedAdvisories) {
-    for (const [id, reason] of advisories) {
-      console.warn(`- ${packageName} ${id}: ${reason}`);
+    for (const [id, approval] of advisories) {
+      console.warn(`- ${packageName} ${id} (expires ${approval.expiresOn}): ${approval.reason}`);
     }
   }
 }

--- a/apps/web/scripts/audit-production.mjs
+++ b/apps/web/scripts/audit-production.mjs
@@ -1,0 +1,108 @@
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export const allowedAdvisories = new Map([
+  [
+    "react-router",
+    new Map([
+      [
+        "GHSA-qwww-vcr4-c8h2",
+        "Only affects unstable React Router RSC APIs, which this SPA does not use; remove when 8.3.0 is published on npm.",
+      ],
+    ]),
+  ],
+]);
+
+function advisoryId(via) {
+  return via.url?.match(/GHSA-[a-z0-9-]+/i)?.[0];
+}
+
+export function findUnapprovedPackages(vulnerabilities, allowlist = allowedAdvisories) {
+  const memo = new Map();
+
+  function hasUnapprovedAdvisory(packageName, visiting = new Set()) {
+    if (memo.has(packageName)) return memo.get(packageName);
+    // npm currently emits an acyclic advisory graph. Treat malformed cycles as
+    // unapproved so an unexpected audit shape cannot weaken the security gate.
+    if (visiting.has(packageName)) return true;
+
+    const vulnerability = vulnerabilities[packageName];
+    if (!vulnerability || !Array.isArray(vulnerability.via)) return true;
+
+    const nextVisiting = new Set(visiting).add(packageName);
+    const unapproved = vulnerability.via.some((via) => {
+      if (typeof via === "string") {
+        return hasUnapprovedAdvisory(via, nextVisiting);
+      }
+
+      const id = advisoryId(via);
+      return !id || !allowlist.get(packageName)?.has(id);
+    });
+
+    memo.set(packageName, unapproved);
+    return unapproved;
+  }
+
+  return Object.keys(vulnerabilities).filter((packageName) => hasUnapprovedAdvisory(packageName));
+}
+
+function run() {
+  const audit = spawnSync("npm", ["audit", "--omit=dev", "--json"], {
+    encoding: "utf8",
+    shell: false,
+  });
+
+  if (audit.error) {
+    console.error(`Unable to run npm audit: ${audit.error.message}`);
+    process.exit(1);
+  }
+
+  let report;
+  try {
+    report = JSON.parse(audit.stdout);
+  } catch (error) {
+    console.error("npm audit did not return valid JSON.");
+    if (audit.stderr) console.error(audit.stderr.trim());
+    console.error(error);
+    process.exit(1);
+  }
+
+  const vulnerabilities = report.vulnerabilities ?? {};
+  if (report.error || (audit.status !== 0 && Object.keys(vulnerabilities).length === 0)) {
+    console.error("npm audit failed before producing a vulnerability report.");
+    if (report.error) console.error(JSON.stringify(report.error));
+    if (audit.stderr) console.error(audit.stderr.trim());
+    process.exit(1);
+  }
+
+  const failingPackages = findUnapprovedPackages(vulnerabilities);
+  if (failingPackages.length > 0) {
+    console.error(
+      `npm audit found unapproved production vulnerabilities in: ${failingPackages.join(", ")}`,
+    );
+    for (const packageName of failingPackages) {
+      for (const via of vulnerabilities[packageName].via ?? []) {
+        if (typeof via !== "string") {
+          console.error(`- ${via.severity}: ${via.title} (${via.url})`);
+        }
+      }
+    }
+    process.exit(1);
+  }
+
+  if (Object.keys(vulnerabilities).length === 0) {
+    console.log("npm audit found no production vulnerabilities.");
+    return;
+  }
+
+  console.warn("npm audit reported only explicitly reviewed production advisories:");
+  for (const [packageName, advisories] of allowedAdvisories) {
+    for (const [id, reason] of advisories) {
+      console.warn(`- ${packageName} ${id}: ${reason}`);
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  run();
+}

--- a/apps/web/scripts/audit-production.node-test.mjs
+++ b/apps/web/scripts/audit-production.node-test.mjs
@@ -52,6 +52,27 @@ test("rejects an additional advisory on an otherwise approved package", () => {
   assert.deepEqual(findUnapprovedPackages(vulnerabilities), ["react-router"]);
 });
 
+test("rejects the reviewed advisory after its approval expires", () => {
+  const vulnerabilities = {
+    "react-router": { via: [approvedAdvisory] },
+  };
+
+  assert.deepEqual(findUnapprovedPackages(vulnerabilities, undefined, "2027-01-01"), [
+    "react-router",
+  ]);
+});
+
+test("rejects a malformed approval", () => {
+  const vulnerabilities = {
+    "react-router": { via: [approvedAdvisory] },
+  };
+  const malformedAllowlist = new Map([
+    ["react-router", new Map([["GHSA-qwww-vcr4-c8h2", { reason: "missing expiry" }]])],
+  ]);
+
+  assert.deepEqual(findUnapprovedPackages(vulnerabilities, malformedAllowlist), ["react-router"]);
+});
+
 test("accepts an empty vulnerability report", () => {
   assert.deepEqual(findUnapprovedPackages({}), []);
 });

--- a/apps/web/scripts/audit-production.node-test.mjs
+++ b/apps/web/scripts/audit-production.node-test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findUnapprovedPackages } from "./audit-production.mjs";
+
+const approvedAdvisory = {
+  severity: "high",
+  title: "RSC Mode CSRF Bypass",
+  url: "https://github.com/advisories/GHSA-qwww-vcr4-c8h2",
+};
+
+test("allows the reviewed advisory and its transitive dependent", () => {
+  const vulnerabilities = {
+    "react-router": { via: [approvedAdvisory] },
+    "react-router-dom": { via: ["react-router"] },
+  };
+
+  assert.deepEqual(findUnapprovedPackages(vulnerabilities), []);
+});
+
+test("rejects a new direct advisory and its transitive dependent", () => {
+  const vulnerabilities = {
+    dependency: {
+      via: [
+        {
+          severity: "high",
+          title: "Unexpected vulnerability",
+          url: "https://github.com/advisories/GHSA-aaaa-bbbb-cccc",
+        },
+      ],
+    },
+    parent: { via: ["dependency"] },
+  };
+
+  assert.deepEqual(findUnapprovedPackages(vulnerabilities), ["dependency", "parent"]);
+});
+
+test("rejects an additional advisory on an otherwise approved package", () => {
+  const vulnerabilities = {
+    "react-router": {
+      via: [
+        approvedAdvisory,
+        {
+          severity: "moderate",
+          title: "New advisory",
+          url: "https://github.com/advisories/GHSA-dddd-eeee-ffff",
+        },
+      ],
+    },
+  };
+
+  assert.deepEqual(findUnapprovedPackages(vulnerabilities), ["react-router"]);
+});
+
+test("accepts an empty vulnerability report", () => {
+  assert.deepEqual(findUnapprovedPackages({}), []);
+});
+
+test("rejects malformed advisory data", () => {
+  assert.deepEqual(findUnapprovedPackages({ dependency: { via: [{}] } }), ["dependency"]);
+  assert.deepEqual(findUnapprovedPackages({ dependency: {} }), ["dependency"]);
+});

--- a/apps/web/src/__tests__/testUtils.tsx
+++ b/apps/web/src/__tests__/testUtils.tsx
@@ -140,6 +140,9 @@ export async function mouseLeave(element: Element) {
 }
 
 export async function renderApp() {
+  // Resolve the route-split library before starting the assertion clock. On a
+  // cold CI worker, transforming this module can exceed waitFor's retry window.
+  await import("../components/Library");
   container = document.createElement("div");
   document.body.appendChild(container);
   const appRoot = createRoot(container);

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -4,17 +4,6 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   build: {
     outDir: "build",
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (!id.includes("node_modules")) return undefined;
-          if (id.includes("hls.js")) return "hls";
-          if (id.includes("react-router")) return "router";
-          if (id.includes("/react/") || id.includes("/react-dom/")) return "react";
-          return "vendor";
-        },
-      },
-    },
   },
   envPrefix: ["VITE_", "REACT_APP_"],
   plugins: [react()],


### PR DESCRIPTION
## Summary

- stop duplicate CI runs by limiting push-triggered CI to `main`; superseded PR runs cancel, while main runs remain complete
- replace the blanket npm-audit failure with a fail-closed, expiring allowlist for the single reviewed React Router RSC advisory
- upgrade `quinn-proto` to 0.11.15 and scope Trivy's temporary React Router exception to the exact lockfile package/version
- remove the unsafe manual Vite chunk split that crashed the production frontend before login rendered
- make Playwright fail quickly on browser exceptions
- add direct tests for the production-audit gate

## Root cause

Every Dependabot branch triggered both `push` and `pull_request` CI runs. Their shared security job failed because npm reports GHSA-qwww-vcr4-c8h2 against React Router 7.18.2; the advisory affects only unstable RSC APIs, while this application is a BrowserRouter SPA and npm does not yet publish the stated 8.3.0 patched release.

Trivy separately reported that advisory plus a fixed `quinn-proto` finding. Quinn is upgraded; the React Router exception is restricted by advisory, package URL, lockfile path, and an expiry date.

The failing main E2E run was separate: the production page crashed with `TypeError: e is not a function` because manual node_modules chunking introduced an unsafe initialization order.

## Validation

- `npm run format:check`
- `npm run lint`
- `npm test` (7 audit-gate tests + 39 Vitest tests)
- `npm run test:coverage`
- `npm run audit:prod`
- `npm run build`
- `cargo metadata --locked --no-deps`
- `make compose-config`
- `actionlint .github/workflows/ci.yml`
- Trivy 0.70 filesystem scan with the committed ignore policy (0 high/critical findings)
- Docker-backed Playwright upload/playback E2E (1 passed)
- independent Claude Opus 4.8 review and re-reviews; all actionable findings addressed

The audit wrapper still fails on every unknown advisory, malformed report or approval, expired approval, audit-network error, or changed npm audit shape.
